### PR TITLE
tind: Make TIND API URL configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,5 +47,8 @@ The following keys are available for configuration in the ``.env`` file:
 ``TIND_API_KEY``
     The API key to use for connecting to TIND.
 
+``TIND_API_URL``
+    The URL to use for connecting to TIND.  Should end in ``/api/v1``.
+
 ``DEFAULT_STORAGE_DIR``
     The default directory to store files retrieved from TIND.

--- a/env.example
+++ b/env.example
@@ -1,2 +1,3 @@
 TIND_API_KEY=To be filled in
+TIND_API_URL=https://digicoll.lib.berkeley.edu/api/v1
 DEFAULT_STORAGE_DIR=/some/local/path

--- a/tests/tind/test_api.py
+++ b/tests/tind/test_api.py
@@ -14,24 +14,32 @@ class TindApiGetTest(unittest.TestCase):
     """Test the tind_get method of the willa.tind.api module."""
     def setUp(self):
         os.environ['TIND_API_KEY'] = 'Test_Key'
+        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
 
     def test_url_building(self):
         """Ensure URL building works correctly."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/test', text='Example')
+            r_mock.get('https://ucb.tind.example/api/v1/test', text='Example')
+            self.assertEqual(api.tind_get('test'), (200, 'Example'))
+
+    def test_url_config(self):
+        """Ensure that changing the config changes the URL."""
+        os.environ['TIND_API_URL'] = 'https://berkeley-test.tind.io/api/v1'
+        with requests_mock.mock() as r_mock:
+            r_mock.get('https://berkeley-test.tind.io/api/v1/test', text='Example')
             self.assertEqual(api.tind_get('test'), (200, 'Example'))
 
     def test_param_passing(self):
         """Ensure that params are passed correctly to API endpoints."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/test', text='Example')
+            r_mock.get('https://ucb.tind.example/api/v1/test', text='Example')
             api.tind_get('test', {'param1': 'testing'})
             self.assertEqual(r_mock.last_request.qs, {'param1': ['testing']})
 
     def test_key(self):
         """Ensure that the TIND API key is passed properly."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/test', text='Example')
+            r_mock.get('https://ucb.tind.example/api/v1/test', text='Example')
             api.tind_get('test')
             headers = r_mock.last_request.headers
             self.assertIn('Authorization', headers)
@@ -45,5 +53,5 @@ class TindApiGetTest(unittest.TestCase):
     def test_invalid_key(self):
         """Ensure that an error is raised when an invalid TIND API key is provided."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/test', status_code=401)
+            r_mock.get('https://ucb.tind.example/api/v1/test', status_code=401)
             self.assertRaises(AuthorizationError, api.tind_get, 'test')

--- a/tests/tind/test_fetch.py
+++ b/tests/tind/test_fetch.py
@@ -16,6 +16,7 @@ class TindFetchMetadataTest(unittest.TestCase):
     """Test the fetch_metadata method of the willa.tind.fetch module."""
     def setUp(self):
         os.environ['TIND_API_KEY'] = 'Test_Key'
+        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
 
     def test_fetch(self):
         """Test a simple record fetch."""
@@ -24,7 +25,7 @@ class TindFetchMetadataTest(unittest.TestCase):
             data = data_f.read()
 
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/record/test/', text=data)
+            r_mock.get('https://ucb.tind.example/api/v1/record/test/', text=data)
             record = fetch.fetch_metadata('test')
 
         self.assertEqual(record.title,
@@ -33,14 +34,14 @@ class TindFetchMetadataTest(unittest.TestCase):
     def test_invalid_record(self):
         """Ensure an error is raised when a record does not exist and the response is a 404."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/record/nothere/',
+            r_mock.get('https://ucb.tind.example/api/v1/record/nothere/',
                        status_code=404)
             self.assertRaises(RecordNotFoundError, fetch.fetch_metadata, 'nothere')
 
     def test_empty_record(self):
         """Ensure an error is raised when a record does not exist and the response is empty."""
         with requests_mock.mock() as r_mock:
-            r_mock.get('https://digicoll.lib.berkeley.edu/api/v1/record/99999999/',
+            r_mock.get('https://ucb.tind.example/api/v1/record/99999999/',
                        text=' \n')
             self.assertRaises(RecordNotFoundError, fetch.fetch_metadata, '99999999')
 
@@ -49,6 +50,7 @@ class TindFetchFileTest(unittest.TestCase):
     """Test the fetch_file method of the willa.tind.fetch module."""
     def setUp(self):
         os.environ['TIND_API_KEY'] = 'Test_Key'
+        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
         os.environ['DEFAULT_STORAGE_DIR'] = tempfile.mkdtemp(prefix='willatest')
 
     def test_file_fetch(self):

--- a/willa/tind/api.py
+++ b/willa/tind/api.py
@@ -35,7 +35,9 @@ def tind_get(endpoint: str, params: dict = None) -> (int, str):
     if params is None:
         params = {}
 
-    resp = requests.get(f"https://digicoll.lib.berkeley.edu/api/v1/{endpoint}",
+    api_base = os.getenv('TIND_API_URL', 'https://digicoll.lib.berkeley.edu/api/v1')
+
+    resp = requests.get(f"{api_base}/{endpoint}",
                         headers=_auth_header(), params=params, timeout=TIMEOUT)
     if resp.status_code == 401:
         raise AuthorizationError('Invalid TIND API key provided')


### PR DESCRIPTION
This allows us to easily switch between test and prod instances.