### PR TITLE
errors: Make a TINDError class and hierarchy

### DIFF
--- a/willa/errors/__init__.py
+++ b/willa/errors/__init__.py
@@ -4,5 +4,4 @@ Defines the errors possibly raised by Willa.
 
 __copyright__ = "© 2025 The Regents of the University of California.  MIT license."
 
-from .auth import AuthorizationError
-from .record import RecordNotFoundError
+from .tind import AuthorizationError, RecordNotFoundError, TINDError

--- a/willa/errors/auth.py
+++ b/willa/errors/auth.py
@@ -1,7 +1,0 @@
-"""
-Defines the AuthorizationError class for Willa.
-"""
-
-
-class AuthorizationError(Exception):
-    """Represents an error with authorization."""

--- a/willa/errors/record.py
+++ b/willa/errors/record.py
@@ -1,7 +1,0 @@
-"""
-Defines the RecordNotFoundError class for Willa.
-"""
-
-
-class RecordNotFoundError(Exception):
-    """Represents an error where the given record was not found in TIND."""

--- a/willa/errors/tind.py
+++ b/willa/errors/tind.py
@@ -1,0 +1,15 @@
+"""
+Defines TIND error classes for Willa.
+"""
+
+
+class TINDError(Exception):
+    """Represents a general TIND API error."""
+
+
+class AuthorizationError(TINDError):
+    """Represents an error with TIND API authorization."""
+
+
+class RecordNotFoundError(TINDError):
+    """Represents an error where the given record was not found in TIND."""


### PR DESCRIPTION
The other error classes are now subclasses of TINDError, which eases programming against the TIND module.

Closes: AP-393