### PR TITLE
Add TIND metadata to the Documents in the vector store

### DIFF
--- a/willa/etl/doc_proc.py
+++ b/willa/etl/doc_proc.py
@@ -10,11 +10,37 @@ from operator import add
 from langchain_community.document_loaders import PyPDFDirectoryLoader
 # from langchain_community.document_loaders import DirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
 from langchain_core.vectorstores.base import VectorStore
+from pymarc.record import Record
+
 import willa.config  # pylint: disable=W0611
+from willa.tind.format_validate_pymarc import pymarc_to_metadata
 
 
-def load_pdfs() -> list:
+def load_pdf(name: str, record: Record | None) -> list[Document]:
+    """Load a given single PDF from storage, including optional PyMARC record.
+
+    :param str name: The name of the file.
+    :param record: The PyMARC record that pertains to the file.
+    :returns: A ``list`` of ``Document``s that can be further used in the pipeline.
+    """
+    directory_path = os.getenv('DEFAULT_STORAGE_DIR', 'tmp/files/')
+    loader = PyPDFDirectoryLoader(directory_path, glob=name, mode="single")
+
+    docs = loader.load()
+    if not docs:
+        print(f"Requested file {name} not found.")
+    else:
+        print(f"Loaded {name} as a document.")
+        if record:
+            for doc in docs:
+                doc.metadata['tindMetadata'] = pymarc_to_metadata(record)
+
+    return docs
+
+
+def load_pdfs() -> list[Document]:
     """Load PDF files from a specified directory using a langchain loader."""
     directory_path = os.getenv('DEFAULT_STORAGE_DIR', 'tmp/files/')
     loader = PyPDFDirectoryLoader(directory_path, mode="single")
@@ -28,7 +54,7 @@ def load_pdfs() -> list:
     return docs
 
 
-def split_doc(doc: dict, chunk_size: int = 1000, chunk_overlap: int = 200) -> list:
+def split_doc(doc: Document, chunk_size: int = 1000, chunk_overlap: int = 200) -> list:
     """Split a document into chunks for vectorization."""
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=chunk_size,

--- a/willa/etl/pipeline.py
+++ b/willa/etl/pipeline.py
@@ -2,11 +2,25 @@
 Run the Willa ETL pipeline.
 """
 
+import os.path
+
+from langchain_core.documents import Document
 from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_core.vectorstores.base import VectorStore
 from langchain_ollama import OllamaEmbeddings
+from pymarc.record import Record
 
-from .doc_proc import load_pdfs, split_all_docs, embed_docs
+from willa.tind.fetch import fetch_metadata, fetch_file_metadata, fetch_file
+from .doc_proc import load_pdf, load_pdfs, split_all_docs, embed_docs
+
+
+def _create_vector_store() -> VectorStore:
+    """Create the vector store if it wasn't specified.
+
+    This is a separate method so we can change properties later.
+    """
+    embeddings = OllamaEmbeddings(model='nomic-embed-text')
+    return InMemoryVectorStore(embeddings)
 
 
 def run_pipeline(vector_store: VectorStore | None = None) -> VectorStore:
@@ -18,11 +32,57 @@ def run_pipeline(vector_store: VectorStore | None = None) -> VectorStore:
     :returns: The vector store where processed documents are stored.
     """
     if vector_store is None:
-        embeddings = OllamaEmbeddings(model='nomic-embed-text')
-        vector_store = InMemoryVectorStore(embeddings)
+        vector_store = _create_vector_store()
 
     docs = load_pdfs()
     splits = split_all_docs(docs)
     embed_docs(splits, vector_store)
+
+    return vector_store
+
+
+def fetch_one_from_tind(tind_id: str, vector_store: VectorStore | None = None) -> VectorStore:
+    """Fetch the files for a TIND record, then load them into the VectorStore.
+
+    :param str tind_id: The ID of the TIND record.
+    :param vector_store: The vector store in which to store the documents.
+                         If no vector store is specified, a new in-memory
+                         vector store will be created.
+    :returns: The vector store where the processed document(s) were stored.
+    """
+    if vector_store is None:
+        vector_store = _create_vector_store()
+
+    record: Record = fetch_metadata(tind_id)
+    files: list[dict] = fetch_file_metadata(tind_id)
+    file_names: list[str] = []
+    docs: list[Document] = []
+
+    for file in files:
+        file_names.append(os.path.basename(fetch_file(file['url'])))
+
+    for name in file_names:
+        docs.extend(load_pdf(name, record))
+
+    splits = split_all_docs(docs)
+    embed_docs(splits, vector_store)
+
+    return vector_store
+
+
+def fetch_from_tind(tind_ids: list[str], vector_store: VectorStore | None = None) -> VectorStore:
+    """Fetch files from a list of TIND records, then load them into a given VectorStore.
+
+    :param list[str] tind_ids: The IDs of the TIND records.
+    :param vector_store: The vector store in which to store the documents.
+                         If no vector store is specified, a new in-memory
+                         vector store will be created.
+    :returns: The vector store where the processed documents were stored.
+    """
+    if vector_store is None:
+        vector_store = _create_vector_store()
+
+    for tind_id in tind_ids:
+        fetch_one_from_tind(tind_id, vector_store)
 
     return vector_store

--- a/willa/tind/fetch.py
+++ b/willa/tind/fetch.py
@@ -3,6 +3,7 @@ Provides routines to fetch information from the TIND API.
 """
 
 import os
+import re
 from io import StringIO
 from typing import Any, List, Tuple
 import json
@@ -50,7 +51,7 @@ def fetch_file(file_url: str, output_dir: str = '') -> str:
     :raises IOError: When the file cannot be saved to the given output directory.
     :returns str: The full path to the file successfully downloaded to the output directory.
     """
-    if not file_url.endswith('/download/'):
+    if not re.match(r'^http.*/download(/)?(\?version=\d+)?$', file_url):
         raise ValueError('URL is not a valid TIND file download URL.')
 
     if output_dir == '':


### PR DESCRIPTION
With a debug statement added, runtime looked a bit like:

```
Python 3.13.5 (main, Jun 11 2025, 15:36:57) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from willa.etl.pipeline import fetch_one_from_tind
>>> store = fetch_one_from_tind('219112')
Loaded zepatos_thalia_2017.pdf as a document.
metadata is now {'producer': 'Adobe PDF Library 11.0', 'creator': 'Acrobat PDFMaker 11 for Word', 'creationdate': '2017-01-20T11:34:10-08:00', 'author': 'Windows', 'company': 'UC Berkeley', 'moddate': '2017-01-20T11:34:15-08:00', 'sourcemodified': 'D:20170120193401', 'title': 'InterviewDetail: TNR 11pt, single space, no space after {Top of page Interview Information--different title', 'source': '/Users/awilcox/Code/UCB/willa/tmp/zepatos_thalia_2017.pdf', 'total_pages': 128, 'tindMetadata': {'tind_id': '219112', 'language': 'eng', 'creator': None, 'title': 'Thalia Zepatos on Research and Messaging in Freedom to Marry', 'type': 'Text', 'description': 'Thalia Zepatos was the Director of Research and Messaging for Freedom to Marry. Zepatos was born in New York City and raised in Yonkers, New York. Zepatos earned her undergraduate degree from American University in Washington DC while at the same began working as an activist, particularly on behalf of the Equal Rights Amendment. Zepatos continued her political work once moving to Portland, Oregon. While in Oregon, she first became involved in LGBT rights work, especially by joining the campaign opposing Oregon’s Ballot Measure 9 in 1992. She then fought against Ballot Measure 36 in 2004, which, when passed, limited marriage to heterosexual couples. Zepatos moved to California work on the “Let California Ring” public education campaign in advance of the anti-gay Proposition 8, which passed in 2008. She joined Freedom to Marry in 2010 as Director of Research and Messaging. In this interview, Zepatos discusses her many years working on behalf of LGBT rights, in particular the freedom to marry movement. She details the extensive, multi-year effort to conduct research on what American’s thought about marriage in general and why they opposed extending marriage to same-sex couples. Furthermore, she explains how she and her colleagues were able to “crack the code” and develop a new set of messages that resonated with voters and changed their minds to be in favor of marriage rights for same-sex couples.', 'rights': 'Researchers may make free and open use of the UC Berkeley Library’s digitized public domain materials. However, some materials in our online collections may be protected by U.S. copyright law (Title 17, U.S.C.). Use or reproduction of materials protected by copyright beyond that allowed by fair use (Title 17, U.S.C. § 107) requires permission from the copyright owners. The use or reproduction of some materials may also be restricted by terms of University of California gift or purchase agreements, privacy and publicity rights, or trademark law. Responsibility for determining rights status and permissibility of any use or reproduction rests exclusively with the researcher. To learn more or make inquiries, please see our permissions policies (https://www.lib.berkeley.edu/visit/bancroft/oral-history-center/projects?section=permissions).', 'subject': ['Advocacy and Philanthropy'], 'coverage': None, 'contributor': ['Zepatos, Thalia interviewee', 'Meeker, Martin interviewer'], 'source': 'oai:digicoll.lib.berkeley.edu:219112 ohc ohc_980 sfg mcleanCalisphere_oai', 'references': 'https://www.youtube.com/edit?o=U&video_id=Y9eWjMzTIFU', 'publisher': 'The Bancroft Library Oral History Center', 'isPartOf': 'Freedom to Marry Oral Histories', 'date': '2017'}}
>>>
```

TODO:

* [ ] Figure out tests.
* [ ] Determine if we want to use `tindMetadata` or `tind_metadata` (to match the other keys).
* [ ] Throw more / harder TIND records at it.