### PR TITLE
Add support for docstring linting via pydoclint

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,6 +32,9 @@ jobs:
     # https://pylint.readthedocs.io/en/latest/user_guide/usage/run.html#exit-codes
       run: |
         pylint -v .
+    - name: Lint docstrings with pydoclint
+      run: |
+        pydoclint .
     - name: Test with unittest
       run: |
         python -m unittest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ test = [
 ]
 lint = [
     "mypy ~= 1.17.1",
+    "pydoclint ~= 0.6.10",
     "pylint ~= 3.3",
 ]
 dev = [
@@ -63,3 +64,7 @@ disallow_untyped_defs = true
 
 [tool.setuptools]
 py-modules = ["willa"]
+
+[tool.pydoclint]
+skip-checking-raises = true
+style = "sphinx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,6 @@ disallow_untyped_defs = true
 py-modules = ["willa"]
 
 [tool.pydoclint]
+allow-init-docstring = true
 skip-checking-raises = true
 style = "sphinx"

--- a/tests/etl/test_pipeline.py
+++ b/tests/etl/test_pipeline.py
@@ -27,6 +27,7 @@ def _load_mock_files(name: str) -> tuple[str, bytes, str]:
 
     :param str name: The name of the mock files.
     :returns: A tuple of (MARC XML, PDF, file metadata as JSON)
+    :rtype: tuple[str, bytes, str]
     """
     with open(os.path.join(__dirname__, f'{name}.xml'), encoding='utf-8') as xml_f:
         xml = xml_f.read()

--- a/tests/tind/setup_files.py
+++ b/tests/tind/setup_files.py
@@ -8,8 +8,8 @@ import os
 def setup_json(file: str) -> Any:
     """Load a mock JSON object from a text file.
 
-    :param file: The name of the file containing the JSON object as text.
-    :returns: A loaded JSON object.
+    :param str file: The name of the file containing the JSON object as text.
+    :returns Any: A loaded JSON object.
     """
     record = os.path.join(os.path.dirname(__file__), file)
     with open(record, encoding='UTF-8') as data_f:
@@ -20,8 +20,8 @@ def setup_json(file: str) -> Any:
 def setup_text_file(file: str) -> str:
     """Load a mock text file.
 
-    :param file: The name of the file containing the text.
-    :returns: The contents of the file as text.
+    :param str file: The name of the file containing the text.
+    :returns str: The contents of the file as text.
     """
     record = os.path.join(os.path.dirname(__file__), file)
     with open(record, encoding='UTF-8') as data_f:

--- a/willa/chatbot/chatbot.py
+++ b/willa/chatbot/chatbot.py
@@ -52,7 +52,7 @@ class Chatbot:  # pylint: disable=R0903
         """Ask a question of this Willa chatbot instance.
 
         :param str question: The question to ask.
-        :returns: The answer given by the model.
+        :returns str: The answer given by the model.
         """
         matching_docs = self.vector_store.similarity_search(question)
         context = '\n\n'.join(doc.page_content for doc in matching_docs)

--- a/willa/chatbot/chatbot.py
+++ b/willa/chatbot/chatbot.py
@@ -41,8 +41,8 @@ class Chatbot:  # pylint: disable=R0903
     def __init__(self, vector_store: VectorStore, model: BaseChatModel):
         """Create a new Willa chatbot instance.
 
-        :param vector_store: The vector store to use for searching.
-        :param model: The LLM to use for processing.
+        :param VectorStore vector_store: The vector store to use for searching.
+        :param BaseChatModel model: The LLM to use for processing.
         """
         self.vector_store = vector_store
         self.model = model

--- a/willa/errors/tind.py
+++ b/willa/errors/tind.py
@@ -13,8 +13,8 @@ class TINDError(Exception):
 
         :param int status: The HTTP status code associated with the response.
         :param str maybe_json: The response text, hopefully in JSON format.
-        :returns: A TINDError with a suitable message based on the response.
-                  If the response wasn't JSON, "Non-JSON response" will be used.
+        :returns Exception: A TINDError with a suitable message based on the response.
+                            If the response wasn't JSON, "Non-JSON response" will be used.
         """
         try:
             j = json.loads(maybe_json)

--- a/willa/etl/doc_proc.py
+++ b/willa/etl/doc_proc.py
@@ -25,8 +25,8 @@ def load_pdf(name: str, record: Record | None) -> list[Document]:
     """Load a given single PDF from storage, including optional PyMARC record.
 
     :param str name: The name of the file.
-    :param record: The PyMARC record that pertains to the file.
-    :returns: A ``list`` of ``Document``s that can be further used in the pipeline.
+    :param Record|None record: The PyMARC record that pertains to the file.
+    :returns list[Document]: A ``list`` of ``Document``s that can be further used in the pipeline.
     """
     directory_path = os.path.dirname(name)
     loader = PyPDFDirectoryLoader(directory_path, glob=os.path.basename(name), mode="single")
@@ -56,7 +56,7 @@ def load_pdfs() -> list[Document]:
 
             [...]: One or more PDF files that comprise the TIND record.
 
-    :returns: All documents successfully loaded.
+    :returns list[Document]: All documents successfully loaded.
     """
     directory_path = os.getenv('DEFAULT_STORAGE_DIR', 'tmp/pdfs')
     docs: list[Document] = []

--- a/willa/etl/pipeline.py
+++ b/willa/etl/pipeline.py
@@ -30,10 +30,10 @@ def _create_vector_store() -> VectorStore:
 def run_pipeline(vector_store: VectorStore | None = None) -> VectorStore:
     """Run the ETL pipeline for Willa.
 
-    :param vector_store: The vector store in which to store processed documents.
-                         If no vector store is specified, a new
-                         in-memory vector store will be created.
-    :returns: The vector store where processed documents are stored.
+    :param VectorStore|None vector_store: The vector store in which to store processed documents.
+                                          If no vector store is specified, a new
+                                          in-memory vector store will be created.
+    :returns VectorStore: The vector store where processed documents are stored.
     """
     if vector_store is None:
         vector_store = _create_vector_store()
@@ -55,8 +55,8 @@ def _process_one_tind_record(record: Record, vector_store: VectorStore | None = 
     for each record returned in the search.
 
     :param Record record: The PyMARC Record object associated with the TIND record.
-    :param vector_store: The vector store in which to store the documents.
-                         If None, vector processing will be skipped.
+    :param VectorStore|None vector_store: The vector store in which to store the documents.
+                                          If None, vector processing will be skipped.
     """
     tind_id: str = record['001'].value()
     files: list[dict] = fetch_file_metadata(tind_id)
@@ -89,9 +89,9 @@ def fetch_one_from_tind(tind_id: str, vector_store: VectorStore | None = None) -
     """Fetch the files for a TIND record, then load them into the VectorStore.
 
     :param str tind_id: The ID of the TIND record.
-    :param vector_store: The vector store in which to store the documents.
-                         If no vector store is specified, files will be fetched
-                         but not processed into a vector store.
+    :param VectorStore|None vector_store: The vector store in which to store the documents.
+                                          If no vector store is specified, files will be fetched
+                                          but not processed into a vector store.
     """
     record: Record = fetch_metadata(tind_id)
     _process_one_tind_record(record, vector_store)
@@ -101,9 +101,9 @@ def fetch_from_tind(tind_ids: list[str], vector_store: VectorStore | None = None
     """Fetch files from a list of TIND records, then load them into a given VectorStore.
 
     :param list[str] tind_ids: The IDs of the TIND records.
-    :param vector_store: The vector store in which to store the documents.
-                         If no vector store is specified, files will be fetched
-                         but not processed into a vector store.
+    :param VectorStore|None vector_store: The vector store in which to store the documents.
+                                          If no vector store is specified, files will be fetched
+                                          but not processed into a vector store.
     """
     for tind_id in tind_ids:
         fetch_one_from_tind(tind_id, vector_store)
@@ -113,9 +113,9 @@ def fetch_all_from_search_query(query: str, vector_store: VectorStore | None = N
     """Fetch all TIND records that match a given search query, then download them.
 
     :param str query: The search query to run against the TIND catalogue.
-    :param vector_store: The vector store in which to store the documents.
-                         If no vector store is specified, files will be fetched
-                         but not processed into a vector store.
+    :param VectorStore|None vector_store: The vector store in which to store the documents.
+                                          If no vector store is specified, files will be fetched
+                                          but not processed into a vector store.
     """
     results = search(query, 'pymarc')
     for record in results:

--- a/willa/tind/api.py
+++ b/willa/tind/api.py
@@ -38,7 +38,8 @@ def tind_get(endpoint: str, params: dict | None = None) -> Tuple[int, str]:
     :param dict|None params: Extra query parameters to send.
                              For example, ``{'of': 'xm'}``.
     :raises AuthorizationError: If an invalid TIND API key is provided.
-    :returns Tuple[int,str]: A tuple of the HTTP status code and response text (if any).
+    :returns: A tuple of the HTTP status code and response text (if any).
+    :rtype: Tuple[int, str]
     """
     if params is None:
         params = {}
@@ -60,7 +61,8 @@ def tind_download(url: str, output_dir: str) -> Tuple[int, str]:
     :param str url: The TIND file download URL.
     :param str output_dir: The path to the directory in which to save the file.
     :raises AuthorizationError: If an invalid TIND API key is provided.
-    :returns Tuple[int,str]: The HTTP status code.
+    :returns: The HTTP status code.
+    :rtype: Tuple[int, str]
     """
     resp = requests.get(url, headers=_auth_header(), timeout=TIMEOUT)
     status = resp.status_code

--- a/willa/tind/api.py
+++ b/willa/tind/api.py
@@ -18,7 +18,11 @@ TIMEOUT: int = 30
 
 
 def _auth_header() -> dict:
-    """Returns the Authorization header needed for TIND API calls."""
+    """Returns the Authorization header needed for TIND API calls.
+
+    :raises AuthorizationError: If no TIND API key is provided in the environment.
+    :returns dict: The ``Authorization`` header to use for the HTTP request.
+    """
     token = os.getenv('TIND_API_KEY', None)
     if token is None:
         raise AuthorizationError('Missing TIND API key')
@@ -31,9 +35,10 @@ def tind_get(endpoint: str, params: dict | None = None) -> Tuple[int, str]:
 
     :param str endpoint: The TIND API endpoint to query.
                          For example, ``'record/1/'``.
-    :param dict params: Extra query parameters to send.
-                        For example, ``{'of': 'xm'}``.
-    :returns: A tuple of the HTTP status code and response text (if any).
+    :param dict|None params: Extra query parameters to send.
+                             For example, ``{'of': 'xm'}``.
+    :raises AuthorizationError: If an invalid TIND API key is provided.
+    :returns Tuple[int,str]: A tuple of the HTTP status code and response text (if any).
     """
     if params is None:
         params = {}
@@ -54,7 +59,8 @@ def tind_download(url: str, output_dir: str) -> Tuple[int, str]:
 
     :param str url: The TIND file download URL.
     :param str output_dir: The path to the directory in which to save the file.
-    :returns: The HTTP status code.
+    :raises AuthorizationError: If an invalid TIND API key is provided.
+    :returns Tuple[int,str]: The HTTP status code.
     """
     resp = requests.get(url, headers=_auth_header(), timeout=TIMEOUT)
     status = resp.status_code

--- a/willa/tind/fetch.py
+++ b/willa/tind/fetch.py
@@ -147,7 +147,8 @@ def _retrieve_xml_search_id(response: str) -> Tuple[Any, str]:
     """Creates a parsable XML and retrieves search_id from the TIND result set for pagination.
 
     :param str response: The string returned from the Tind search call.
-    :returns Tuple[Any,str]: A Search ID and a parsable XML document.
+    :returns: A Search ID and a parsable XML document.
+    :rtype: Tuple[Any, str]
     """
     E.register_namespace('', "http://www.loc.gov/MARC21/slim")
     xml = E.fromstring(response)

--- a/willa/tind/format_validate_pymarc.py
+++ b/willa/tind/format_validate_pymarc.py
@@ -10,8 +10,8 @@ from pymarc import Record
 def field_required(pymarc_record: Record) -> None:
     """Ensure the given record has values for fields 001 and 245.
 
-    :param pymarc_record: The record to check.
-    :raises: KeyError if required values are not present.
+    :param Record pymarc_record: The record to check.
+    :raises KeyError: If required values are not present.
     """
     errors = []
     if not '245' in pymarc_record or pymarc_record['245']['a'] is None:
@@ -27,8 +27,8 @@ def field_required(pymarc_record: Record) -> None:
 def get_generic_fields(pymarc_record: Record) -> dict:
     """Process a record into a ``dict``; missing values will be set to None.
 
-    :param pymarc_record: The record to process.
-    :returns: The processed PyMARC record as a ``dict`` of values.
+    :param Record pymarc_record: The record to process.
+    :returns dict: The processed PyMARC record as a ``dict`` of values.
     """
 
     fields_hash: dict[str, Any] = {}
@@ -56,11 +56,11 @@ def get_sub_by_field_and_indicators(record: Record, field_tag: str,
 
     :param Record record: The record to process.
     :param str field_tag: The field tag.
-    :param str ind1: The first indicator (or None for no indicator).
-    :param str ind2: The second indicator (or None for no indicator).
-    :param str subfield_code: The subfield code (or None for no code).
+    :param str|None ind1: The first indicator (or None for no indicator).
+    :param str|None ind2: The second indicator (or None for no indicator).
+    :param str|None subfield_code: The subfield code (or None for no code).
 
-    :returns: Either a ``list`` of fields or a ``str`` for a single field.
+    :returns list|str|None: Either a ``list`` of fields or a ``str`` for a single field.
     """
     results: list[str] = []
 
@@ -83,9 +83,9 @@ def get_sub_by_field_and_indicators(record: Record, field_tag: str,
 def parse_pymarc(pymarc_record: Record) -> dict:
     """Parse a PyMARC record into a ``dict`` suitable for document parsing.
 
-    :param pymarc_record: The record to parse.
-    :returns: A ``dict`` containing all relevant MARC fields.
-              Missing fields will be set to None.
+    :param Record pymarc_record: The record to parse.
+    :returns dict: A ``dict`` containing all relevant MARC fields.
+                   Missing fields will be set to None.
     """
 
     # Will raise error if there is no '001' or '245'
@@ -131,8 +131,8 @@ KEY_MAPPINGS: dict = {
 def pymarc_to_metadata(record: Record) -> dict:
     """Parse a PyMARC record into document metadata.
 
-    :param record: The record to parse.
-    :returns: A ``dict`` containing document metadata.
+    :param Record record: The record to parse.
+    :returns dict: A ``dict`` containing document metadata.
     """
     marc_values = parse_pymarc(record)
 

--- a/willa/tind/format_validate_pymarc.py
+++ b/willa/tind/format_validate_pymarc.py
@@ -60,7 +60,8 @@ def get_sub_by_field_and_indicators(record: Record, field_tag: str,
     :param str|None ind2: The second indicator (or None for no indicator).
     :param str|None subfield_code: The subfield code (or None for no code).
 
-    :returns list|str|None: Either a ``list`` of fields or a ``str`` for a single field.
+    :returns: Either a ``list`` of fields or a ``str`` for a single field.
+    :rtype: list | str | None
     """
     results: list[str] = []
 

--- a/willa/tind/format_validate_pymarc.py
+++ b/willa/tind/format_validate_pymarc.py
@@ -14,10 +14,10 @@ def field_required(pymarc_record: Record) -> None:
     :raises KeyError: If required values are not present.
     """
     errors = []
-    if not '245' in pymarc_record or pymarc_record['245']['a'] is None:
+    if '245' not in pymarc_record or pymarc_record['245']['a'] is None:
         errors.append("245 missing or None")
 
-    if not '001' in pymarc_record or pymarc_record['001'].data is None:
+    if '001' not in pymarc_record or pymarc_record['001'].data is None:
         errors.append("001 missing or None")
 
     if len(errors) > 0:
@@ -40,7 +40,7 @@ def get_generic_fields(pymarc_record: Record) -> dict:
             fields_hash[key] = None
         else:
             fields = pymarc_record.get_fields(key)
-            if(len(fields)) > 1:
+            if len(fields) > 1:
                 fields_hash[key] = [rec.value() for rec in fields]
             else:
                 fields_hash[key] = pymarc_record[key].value()
@@ -94,8 +94,8 @@ def parse_pymarc(pymarc_record: Record) -> dict:
 
     marc_values = get_generic_fields(pymarc_record)
 
-    marc_values['85642u'] = get_sub_by_field_and_indicators(pymarc_record, '856', '4','2', 'u')
-    marc_values['852__c'] = get_sub_by_field_and_indicators(pymarc_record, '852', ' ',' ', 'c')
+    marc_values['85642u'] = get_sub_by_field_and_indicators(pymarc_record, '856', '4', '2', 'u')
+    marc_values['852__c'] = get_sub_by_field_and_indicators(pymarc_record, '852', ' ', ' ', 'c')
     marc_values['982__b'] = get_sub_by_field_and_indicators(pymarc_record, '982', None, None, 'b')
     marc_values['260__c'] = get_sub_by_field_and_indicators(pymarc_record, '260', None, None, 'c')
 


### PR DESCRIPTION
We can't enable this in CI until there is an upstream fix for an issue related to spacing (https://github.com/jsh9/pydoclint/issues/253).

It will still help us in development until we can enable it in CI.