### PR TITLE
Refactor configuration management

### DIFF
--- a/tests/etl/test_doc_proc.py
+++ b/tests/etl/test_doc_proc.py
@@ -11,7 +11,8 @@ from langchain_core.documents import Document
 from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_ollama import OllamaEmbeddings
 from pymarc import parse_xml_to_array
-from willa.config import OLLAMA_URL
+
+from willa.config import CONFIG
 from willa.etl.doc_proc import (
     load_pdf, load_pdfs,
     split_doc, split_all_docs,
@@ -24,8 +25,8 @@ class DocumentProcessingTest(unittest.TestCase):
     """Test suite for document processing utilities."""
 
     def setUp(self) -> None:
-        os.environ['DEFAULT_STORAGE_DIR'] = tempfile.mkdtemp(prefix='willatest')
-        tind_dir = os.path.join(os.environ['DEFAULT_STORAGE_DIR'], '103806')
+        CONFIG['DEFAULT_STORAGE_DIR'] = tempfile.mkdtemp(prefix='willatest')
+        tind_dir = os.path.join(CONFIG['DEFAULT_STORAGE_DIR'], '103806')
         os.mkdir(tind_dir)
         shutil.copyfile(os.path.join(os.path.dirname(__file__), 'parnell_kerby.pdf'),
                         os.path.join(tind_dir, 'parnell_kerby.pdf'))
@@ -72,7 +73,7 @@ class DocumentProcessingTest(unittest.TestCase):
         docs = load_pdfs()
         if docs:
             chunked_docs = split_all_docs(docs)
-            embeddings = OllamaEmbeddings(model=self.embedding_model, base_url=OLLAMA_URL)
+            embeddings = OllamaEmbeddings(model=self.embedding_model, base_url=CONFIG['OLLAMA_URL'])
             vector_store = InMemoryVectorStore(embeddings)
             embed_ids = embed_docs(chunked_docs, vector_store)
             self.assertGreater(len(embed_ids), 0, "Should return IDs for embedded documents.")

--- a/tests/tind/test_api.py
+++ b/tests/tind/test_api.py
@@ -2,10 +2,11 @@
 Test the low-level TIND API functionality of Willa.
 """
 
-import os
 import unittest
 
 import requests_mock
+
+from willa.config import CONFIG
 from willa.errors import AuthorizationError
 from willa.tind import api
 
@@ -13,8 +14,8 @@ from willa.tind import api
 class TindApiGetTest(unittest.TestCase):
     """Test the tind_get method of the willa.tind.api module."""
     def setUp(self) -> None:
-        os.environ['TIND_API_KEY'] = 'Test_Key'
-        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
+        CONFIG['TIND_API_KEY'] = 'Test_Key'
+        CONFIG['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
 
     def test_url_building(self) -> None:
         """Ensure URL building works correctly."""
@@ -24,7 +25,7 @@ class TindApiGetTest(unittest.TestCase):
 
     def test_url_config(self) -> None:
         """Ensure that changing the config changes the URL."""
-        os.environ['TIND_API_URL'] = 'https://berkeley-test.tind.io/api/v1'
+        CONFIG['TIND_API_URL'] = 'https://berkeley-test.tind.io/api/v1'
         with requests_mock.mock() as r_mock:
             r_mock.get('https://berkeley-test.tind.io/api/v1/test', text='Example')
             self.assertEqual(api.tind_get('test'), (200, 'Example'))
@@ -47,7 +48,7 @@ class TindApiGetTest(unittest.TestCase):
 
     def test_without_key(self) -> None:
         """Ensure that an error is raised when the TIND API key is missing."""
-        del os.environ['TIND_API_KEY']
+        del CONFIG['TIND_API_KEY']
         self.assertRaises(AuthorizationError, api.tind_get, 'test')
 
     def test_invalid_key(self) -> None:

--- a/tests/tind/test_fetch.py
+++ b/tests/tind/test_fetch.py
@@ -2,12 +2,13 @@
 Test the TIND fetch record functionality of Willa.
 """
 
-import os
+import os.path
 import pathlib
 import tempfile
 import unittest
 
 import requests_mock
+from willa.config import CONFIG
 from willa.errors import AuthorizationError, RecordNotFoundError
 from willa.tind import fetch
 
@@ -15,8 +16,8 @@ from willa.tind import fetch
 class TindFetchMetadataTest(unittest.TestCase):
     """Test the fetch_metadata method of the willa.tind.fetch module."""
     def setUp(self) -> None:
-        os.environ['TIND_API_KEY'] = 'Test_Key'
-        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
+        CONFIG['TIND_API_KEY'] = 'Test_Key'
+        CONFIG['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
 
     def test_fetch(self) -> None:
         """Test a simple record fetch."""
@@ -49,9 +50,9 @@ class TindFetchMetadataTest(unittest.TestCase):
 class TindFetchFileTest(unittest.TestCase):
     """Test the fetch_file method of the willa.tind.fetch module."""
     def setUp(self) -> None:
-        os.environ['TIND_API_KEY'] = 'Test_Key'
-        os.environ['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
-        os.environ['DEFAULT_STORAGE_DIR'] = tempfile.mkdtemp(prefix='willatest')
+        CONFIG['TIND_API_KEY'] = 'Test_Key'
+        CONFIG['TIND_API_URL'] = 'https://ucb.tind.example/api/v1'
+        CONFIG['DEFAULT_STORAGE_DIR'] = tempfile.mkdtemp(prefix='willatest')
 
     def test_file_fetch(self) -> None:
         """Test a simple file fetch."""
@@ -62,7 +63,7 @@ class TindFetchFileTest(unittest.TestCase):
             r_mock.get(dl_path, text=expected)
             fetch.fetch_file(dl_path)
 
-        path = pathlib.Path(os.environ['DEFAULT_STORAGE_DIR'], 'test.txt')
+        path = pathlib.Path(CONFIG['DEFAULT_STORAGE_DIR'], 'test.txt')
         self.assertTrue(path.is_file(), 'File should be saved to default path')
         self.assertEqual(path.read_text(encoding='utf-8'), expected,
                          'File should have expected contents')
@@ -78,9 +79,9 @@ class TindFetchFileTest(unittest.TestCase):
                        headers={'Content-Disposition': 'attachment; filename="usethis.txt"'})
             fetch.fetch_file(dl_path)
 
-        path = pathlib.Path(os.environ['DEFAULT_STORAGE_DIR'], 'notthisname.txt')
+        path = pathlib.Path(CONFIG['DEFAULT_STORAGE_DIR'], 'notthisname.txt')
         self.assertFalse(path.is_file(), 'File should be saved to correct name')
-        path = pathlib.Path(os.environ['DEFAULT_STORAGE_DIR'], 'usethis.txt')
+        path = pathlib.Path(CONFIG['DEFAULT_STORAGE_DIR'], 'usethis.txt')
         self.assertTrue(path.is_file(), 'File should be saved to correct name')
         self.assertEqual(path.read_text(encoding='utf-8'), expected,
                          'File should have expected contents')
@@ -96,7 +97,7 @@ class TindFetchFileTest(unittest.TestCase):
                 r_mock.get(dl_path, text=expected)
                 fetch.fetch_file(dl_path, custom_path)
 
-            path = pathlib.Path(os.environ['DEFAULT_STORAGE_DIR'], 'custom.txt')
+            path = pathlib.Path(CONFIG['DEFAULT_STORAGE_DIR'], 'custom.txt')
             self.assertFalse(path.is_file(), 'File should not be saved in default path')
 
             path = pathlib.Path(custom_path, 'custom.txt')
@@ -136,4 +137,4 @@ class TindFetchFileTest(unittest.TestCase):
             self.assertRaises(AuthorizationError, fetch.fetch_file, dl_path)
 
     def tearDown(self) -> None:
-        pathlib.Path(os.environ['DEFAULT_STORAGE_DIR']).rmdir()
+        pathlib.Path(CONFIG['DEFAULT_STORAGE_DIR']).rmdir()

--- a/tests/tind/test_fetch_file_metadata.py
+++ b/tests/tind/test_fetch_file_metadata.py
@@ -2,11 +2,11 @@
 Test the TIND fetch record functionality of Willa.
 """
 
-import os
 import unittest
 
 import requests_mock
 
+from willa.config import CONFIG
 from willa.errors import TINDError
 from willa.tind import fetch
 from . import setup_files
@@ -17,7 +17,7 @@ class TindFetchFileMetadataTest(unittest.TestCase):
 
     def setUp(self) -> None:
         """Create a fake Tind API key"""
-        os.environ['TIND_API_KEY'] = 'Test_Key'
+        CONFIG['TIND_API_KEY'] = 'Test_Key'
 
     def test_fetch_file_metadata(self) -> None:
         """Fetch a Tind record with a single file.

--- a/tests/tind/test_fetch_metadata.py
+++ b/tests/tind/test_fetch_metadata.py
@@ -2,12 +2,12 @@
 Test the TIND search and fetch functionality of Willa.
 """
 
-import os
 import unittest
 
 # import xml.etree.ElementTree as ET
 import requests_mock
 
+from willa.config import CONFIG
 from willa.errors import TINDError
 from willa.tind import fetch
 from . import setup_files
@@ -17,7 +17,7 @@ class TindSearchTest(unittest.TestCase):
     """Test the search methods of the willa.tind.fetch module."""
     def setUp(self) -> None:
         """Provide a fake Tind API key"""
-        os.environ['TIND_API_KEY'] = 'Test_Key'
+        CONFIG['TIND_API_KEY'] = 'Test_Key'
 
     def test_fetch_search_id(self) -> None:
         """fetch_ids_search should return a list of Tind ID's if there are results"""

--- a/tests/tind/test_format_tind_context.py
+++ b/tests/tind/test_format_tind_context.py
@@ -2,15 +2,14 @@
 Test the functionality of willa.tind.format_tind_context
 """
 
-import os
-from io import StringIO
+import os.path
 import unittest
+from io import StringIO
 
 from pymarc import parse_xml_to_array
 
-from willa.tind import format_tind_context
-from willa.tind import format_validate_pymarc
 from willa.etl.doc_proc import load_pdf
+from willa.tind import format_tind_context, format_validate_pymarc
 from . import setup_files
 
 

--- a/willa/chatbot/chatbot.py
+++ b/willa/chatbot/chatbot.py
@@ -1,21 +1,13 @@
 """Implements the Chatbot class for Willa."""
 
-import os
-
 from langchain_core.language_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.vectorstores.base import VectorStore
 
-import willa.config  # pylint: disable=W0611
+from willa.config import CONFIG
 from willa.tind import format_tind_context
 
-_PROMPT_FILE: str = os.getenv('PROMPT_TEMPLATE',
-                              os.path.join(os.path.dirname(__package__),
-                                           'prompt_templates', 'initial_prompt.txt'))
-"""The file from which to load the system prompt."""
-
-
-with open(_PROMPT_FILE, encoding='utf-8') as f:
+with open(CONFIG['PROMPT_TEMPLATE'], encoding='utf-8') as f:
     _SYS_PROMPT: str = f.read()
     """The system prompt."""
 

--- a/willa/chatbot/cli.py
+++ b/willa/chatbot/cli.py
@@ -8,7 +8,7 @@ from langchain_ollama import ChatOllama
 from rich.console import Console
 
 from willa.chatbot import Chatbot
-from willa.config import OLLAMA_URL, get_lance
+from willa.config import CONFIG, get_lance
 
 
 def main() -> None:
@@ -26,7 +26,7 @@ def main() -> None:
     with console.status("[bold green]Loading documents..."):
         my_store = get_lance()
 
-    model = ChatOllama(model=args.model, temperature=0.5, base_url=OLLAMA_URL)
+    model = ChatOllama(model=args.model, temperature=0.5, base_url=CONFIG['OLLAMA_URL'])
 
     while True:
         bot = Chatbot(my_store, model)

--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -4,25 +4,48 @@ Load the configuration for Willa into the environment.
 
 __copyright__ = "© 2025 The Regents of the University of California.  MIT license."
 
-import os
-from dotenv import load_dotenv
+import os.path
+from dotenv import dotenv_values
 
 from langchain_community.vectorstores import LanceDB
 from langchain_ollama import OllamaEmbeddings
 
-
-load_dotenv()
-
-
-OLLAMA_URL: str = os.getenv('OLLAMA_URL', 'http://localhost:11434')
-"""The URL to use to connect to Ollama."""
+from willa.errors.config import ImproperConfigurationError
 
 
-LANCEDB_URI: str = os.getenv('LANCEDB_URI', '/lancedb')
-"""The URI to use to connect to LanceDB."""
+DEFAULTS: dict[str, str] = {
+    'CALNET_ENV': 'test',
+    'CHAT_MODEL': 'gemma3n:e4b',
+    'CHAT_TEMPERATURE': '0.5',
+    'LANCEDB_URI': '/lancedb',
+    'OLLAMA_URL': 'http://localhost:11434',
+    'PROMPT_TEMPLATE': os.path.join(os.path.dirname(__package__),
+                                    'prompt_templates', 'initial_prompt.txt'),
+    'TIND_API_URL': 'https://digicoll.lib.berkeley.edu/api/v1',
+}
+"""The defaults for configuration variables not set in the .env file."""
+
+
+_RAW: dict[str, str | None] = dotenv_values()
+"""The configuration variables from the .env file."""
+
+
+_PROCESSED: dict[str, str] = {key: _RAW[key] or '' for key in _RAW.keys()}
+"""Configuration variables from the .env file, with Nones replaced with an empty string."""
+
+
+CONFIG: dict[str, str] = {
+    **DEFAULTS,
+    **_PROCESSED
+}
+"""The loaded configuration variables."""
+
+
+if CONFIG['DEFAULT_STORAGE_DIR'] is None:
+    raise ImproperConfigurationError('A storage directory must be set.')
 
 
 def get_lance() -> LanceDB:
     """Return a configured instance of a LanceDB class."""
-    embeddings = OllamaEmbeddings(model='nomic-embed-text', base_url=OLLAMA_URL)
-    return LanceDB(embedding=embeddings, uri=LANCEDB_URI, table_name='willa')
+    embeddings = OllamaEmbeddings(model='nomic-embed-text', base_url=CONFIG['OLLAMA_URL'])
+    return LanceDB(embedding=embeddings, uri=CONFIG['LANCEDB_URI'], table_name='willa')

--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -18,7 +18,7 @@ OLLAMA_URL: str = os.getenv('OLLAMA_URL', 'http://localhost:11434')
 """The URL to use to connect to Ollama."""
 
 
-LANCEDB_URI: str = os.getenv('LANCEDB_URI', '/tmp/lancedb-storage')
+LANCEDB_URI: str = os.getenv('LANCEDB_URI', '/lancedb')
 """The URI to use to connect to LanceDB."""
 
 

--- a/willa/errors/__init__.py
+++ b/willa/errors/__init__.py
@@ -4,4 +4,5 @@ Defines the errors possibly raised by Willa.
 
 __copyright__ = "© 2025 The Regents of the University of California.  MIT license."
 
+from .config import ImproperConfigurationError
 from .tind import AuthorizationError, RecordNotFoundError, TINDError

--- a/willa/errors/config.py
+++ b/willa/errors/config.py
@@ -1,0 +1,7 @@
+"""
+Defines configuration error classes for Willa.
+"""
+
+
+class ImproperConfigurationError(Exception):
+    """Defines an error that is raised when improper configuration is detected."""

--- a/willa/etl/doc_proc.py
+++ b/willa/etl/doc_proc.py
@@ -4,7 +4,7 @@ and split them into chunks for vectorization.
 """
 
 import json
-import os
+import os.path
 from functools import reduce
 from operator import add
 from pathlib import Path
@@ -17,7 +17,7 @@ from langchain_core.documents import Document
 from langchain_core.vectorstores.base import VectorStore
 from pymarc.record import Record
 
-import willa.config  # pylint: disable=W0611
+from willa.config import CONFIG
 from willa.tind.format_validate_pymarc import pymarc_to_metadata
 
 
@@ -58,10 +58,9 @@ def load_pdfs() -> list[Document]:
 
     :returns list[Document]: All documents successfully loaded.
     """
-    directory_path = os.getenv('DEFAULT_STORAGE_DIR', 'tmp/pdfs')
     docs: list[Document] = []
 
-    for tind_path in Path(directory_path).iterdir():
+    for tind_path in Path(CONFIG['DEFAULT_STORAGE_DIR']).iterdir():
         if not tind_path.is_dir():
             continue  # We only want directories.
 

--- a/willa/etl/pipeline.py
+++ b/willa/etl/pipeline.py
@@ -10,7 +10,7 @@ from langchain_core.vectorstores.base import VectorStore
 from pymarc.marcxml import record_to_xml
 from pymarc.record import Record
 
-from willa.config import get_lance
+from willa.config import CONFIG, get_lance
 from willa.tind.fetch import fetch_metadata, fetch_file_metadata, fetch_file, search
 from willa.tind.format_validate_pymarc import pymarc_to_metadata
 from .doc_proc import load_pdf, load_pdfs, split_all_docs, embed_docs
@@ -60,7 +60,7 @@ def _process_one_tind_record(record: Record, vector_store: VectorStore | None = 
     file_names: list[str] = []
     docs: list[Document] = []
 
-    tind_dir = os.path.join(os.environ['DEFAULT_STORAGE_DIR'], tind_id)
+    tind_dir = os.path.join(CONFIG['DEFAULT_STORAGE_DIR'], tind_id)
     os.mkdir(tind_dir)
 
     marc: bytes = record_to_xml(record)

--- a/willa/tind/api.py
+++ b/willa/tind/api.py
@@ -3,13 +3,13 @@ Provides low-level access to the TIND API.
 """
 
 
-import os
+import os.path
 import re
 from typing import Tuple
 
 import requests
 
-import willa.config  # pylint: disable=W0611
+from willa.config import CONFIG
 from willa.errors import AuthorizationError
 
 
@@ -23,7 +23,7 @@ def _auth_header() -> dict:
     :raises AuthorizationError: If no TIND API key is provided in the environment.
     :returns dict: The ``Authorization`` header to use for the HTTP request.
     """
-    token = os.getenv('TIND_API_KEY', None)
+    token = CONFIG.get('TIND_API_KEY', None)
     if token is None:
         raise AuthorizationError('Missing TIND API key')
 
@@ -44,7 +44,7 @@ def tind_get(endpoint: str, params: dict | None = None) -> Tuple[int, str]:
     if params is None:
         params = {}
 
-    api_base = os.getenv('TIND_API_URL', 'https://digicoll.lib.berkeley.edu/api/v1')
+    api_base = CONFIG['TIND_API_URL']
 
     resp = requests.get(f"{api_base}/{endpoint}",
                         headers=_auth_header(), params=params, timeout=TIMEOUT)

--- a/willa/tind/fetch.py
+++ b/willa/tind/fetch.py
@@ -2,16 +2,16 @@
 Provides routines to fetch information from the TIND API.
 """
 
-import os
+import json
 import re
 from io import StringIO
 from typing import Any, Tuple
-import json
 
 import xml.etree.ElementTree as E
 from pymarc.marcxml import parse_xml_to_array
 from pymarc import Record
 
+from willa.config import CONFIG
 from willa.errors import RecordNotFoundError, TINDError
 from .api import tind_get, tind_download
 
@@ -58,7 +58,7 @@ def fetch_file(file_url: str, output_dir: str = '') -> str:
         # This cannot be put as the default value for the parameter because it would set
         # the value at the time this file is imported.  Changes in the environment (whether
         # via config reload, the test infrastructure, etc) would not appear.
-        output_dir = os.environ['DEFAULT_STORAGE_DIR']
+        output_dir = CONFIG['DEFAULT_STORAGE_DIR']
 
     (status, saved_to) = tind_download(file_url, output_dir)
 

--- a/willa/web/app.py
+++ b/willa/web/app.py
@@ -9,7 +9,7 @@ from chainlit.types import ThreadDict, CommandDict
 from langchain_ollama import ChatOllama
 
 from willa.chatbot import Chatbot
-from willa.config import OLLAMA_URL, get_lance
+from willa.config import CONFIG, get_lance
 from willa.web.cas_provider import CASProvider
 from willa.web.inject_custom_auth import add_custom_oauth_provider
 
@@ -21,9 +21,9 @@ STORE = get_lance()
 add_custom_oauth_provider('cas', CASProvider())
 
 
-BOT = Chatbot(STORE, ChatOllama(model=os.getenv('CHAT_MODEL', 'gemma3n:e4b'),
-                                temperature=float(os.getenv('CHAT_TEMPERATURE', '0.5')),
-                                base_url=OLLAMA_URL))
+BOT = Chatbot(STORE, ChatOllama(model=CONFIG['CHAT_MODEL'],
+                                temperature=float(CONFIG['CHAT_TEMPERATURE']),
+                                base_url=CONFIG['OLLAMA_URL']))
 """The Chatbot instance to use for chatting."""
 
 COMMANDS: list[CommandDict] = [

--- a/willa/web/cas_provider.py
+++ b/willa/web/cas_provider.py
@@ -2,7 +2,6 @@
 Provides a Chainlit authentication provider for CAS.
 """
 
-import os
 from typing import Any, Optional, Tuple, Dict
 
 import httpx
@@ -11,20 +10,18 @@ from chainlit.server import app
 from chainlit.user import User
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse
-import willa.config  # pylint: disable=W0611
 
-CALNET_ENV: str = os.environ.get('CALNET_ENV', 'test')
-"""The environment we are running in; either 'test' or 'production'."""
+from willa.config import CONFIG
 
 
-if CALNET_ENV == 'test':
+if CONFIG['CALNET_ENV'] == 'test':
     BASE_URL = "https://auth-test.berkeley.edu/cas/oidc"
     """The base URL for the test instance of CalNet CAS."""
-elif CALNET_ENV == 'production':
+elif CONFIG['CALNET_ENV'] == 'production':
     BASE_URL = "https://auth.berkeley.edu/cas/oidc"
     """The base URL for the production instance of CalNet CAS."""
 else:
-    raise ValueError(f'Unknown CalNet environment {CALNET_ENV}!')
+    raise ValueError(f"Unknown CalNet environment {CONFIG['CALNET_ENV']}!")
 
 
 class CASForbiddenException(HTTPException):
@@ -62,8 +59,8 @@ class CASProvider(OAuthProvider):
     well_known_url = f"{BASE_URL}/.well-known"
 
     def __init__(self) -> None:
-        self.client_id = os.environ['CALNET_OIDC_CLIENT_ID']
-        self.client_secret = os.environ['CALNET_OIDC_CLIENT_SECRET']
+        self.client_id = CONFIG['CALNET_OIDC_CLIENT_ID']
+        self.client_secret = CONFIG['CALNET_OIDC_CLIENT_SECRET']
         self.authorize_params = {
             'response_type': 'code',
             'scope': 'openid profile berkeley_edu_groups',


### PR DESCRIPTION
Instead of using the shell environment, we use a dictionary.  This is cleaner, allows us to explicitly define default variables in a single place (instead of all across the codebase), allows us to override values in tests in a cleaner way, and makes us flexible to different ways of configuration later on.