### PR TITLE
willa: Improvements for max token configuration

### DIFF
--- a/willa/chatbot/graph_manager.py
+++ b/willa/chatbot/graph_manager.py
@@ -46,7 +46,7 @@ class GraphManager:  # pylint: disable=too-few-public-methods
 
         # summarization node assumes same model as chat response generation
         summarization_node = SummarizationNode(
-            max_tokens=int(CONFIG.get('SUMMARIZATION_MAX_TOKENS', '500')),
+            max_tokens=int(CONFIG['SUMMARIZATION_MAX_TOKENS']),
             model=self._model,
             input_messages_key="filtered_messages",
             output_messages_key="summarized_messages"

--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -35,7 +35,7 @@ VALID_VARS: set[str] = {'TIND_API_KEY', 'TIND_API_URL', 'DEFAULT_STORAGE_DIR', '
                         'OLLAMA_URL', 'CHAT_MODEL', 'CHAT_TEMPERATURE', 'CALNET_ENV',
                         'CALNET_OIDC_CLIENT_ID', 'CALNET_OIDC_CLIENT_SECRET', 'LANCEDB_URI',
                         'CHAT_BACKEND', 'EMBED_BACKEND', 'LANGFUSE_HOST', 'LANGFUSE_PUBLIC_KEY',
-                        'LANGFUSE_SECRET_KEY', 'MAX_TOKENS'}
+                        'LANGFUSE_SECRET_KEY', 'SUMMARIZATION_MAX_TOKENS'}
 """Valid configuration variables that could be in the environment."""
 
 


### PR DESCRIPTION
* config: Ensure `VALID_VARS` has the correct name for the environment variable.

* graph_manager: Rely on the config default instead of having a second default defined in the source code.

These fix the review comments I had for #45.