### PR TITLE
docker-compose: Move LocalStack to its own profile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,20 @@ environment by running::
     docker compose up -d
 
 To run prisma studio::
+
     docker compose up -d prisma
+
+Both Ollama and LocalStack can be useful for local development, and use profiles.
+You can start those services by using Docker Compose's profiles setting::
+
+    COMPOSE_PROFILES=localstack docker compose up -d
+    COMPOSE_PROFILES=ollama,localstack docker compose up -d
+    COMPOSE_PROFILES='*' docker compose down
+
+You can also pass the ``--profile`` argument::
+
+    docker compose --profile localstack up -d
+
 
 
 Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
         condition: service_healthy
 
   localstack:
+    profiles:
+      - localstack
     container_name: "localstack-main"
     image: localstack/localstack:4.7
     restart: always


### PR DESCRIPTION
LocalStack is still useful for testing, but is not needed in most cases. Move it to its own profile to save time/resources on dev machines.