### PR TITLE
Implement release/environment tracking in Langfuse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,17 +95,20 @@ environment by running::
 
     docker compose build --pull
     docker compose run prisma migrate deploy
-    docker compose up -d
+    bin/dev
 
-To run prisma studio::
+The ``bin/dev`` command sets a few environment variables for you and then runs
+the appropriate ``compose`` command.
+
+To run Prisma Studio::
 
     docker compose up -d prisma
 
 Both Ollama and LocalStack can be useful for local development, and use profiles.
 You can start those services by using Docker Compose's profiles setting::
 
-    COMPOSE_PROFILES=localstack docker compose up -d
-    COMPOSE_PROFILES=ollama,localstack docker compose up -d
+    COMPOSE_PROFILES=localstack bin/dev
+    COMPOSE_PROFILES=ollama,localstack bin/dev
     COMPOSE_PROFILES='*' docker compose down
 
 You can also pass the ``--profile`` argument::

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Start the Willa development environment, setting a few helpful environment
+# variables and kicking off Docker Compose.
+#
+# Copyright © 2025 The Regents of the University of California.  MIT license.
+
+readonly EXTRA_VERSION="-$(git rev-parse --short=12 HEAD)"
+readonly DEPLOYMENT_ID="${USER}-dev"
+
+if command -v docker 1>/dev/null 2>/dev/null; then
+  readonly DRIVER=docker
+elif command -v podman 1>/dev/null 2>/dev/null; then
+  readonly DRIVER=podman
+else
+  printf "No Docker or Podman found; quitting.\n"
+  exit 1
+fi
+
+export EXTRA_VERSION DEPLOYMENT_ID
+${DRIVER} compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     env_file: .env
     environment:
       <<: *dbconfig
+      EXTRA_VERSION: ${EXTRA_VERSION:-}
+      DEPLOYMENT_ID: ${DEPLOYMENT_ID:-compose-unknown}
     volumes:
       - ./.data/lancedb:/lancedb
       - ./tmp:/pdfs

--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -4,6 +4,7 @@ Load the configuration for Willa into the environment.
 
 __copyright__ = "© 2025 The Regents of the University of California.  MIT license."
 
+import importlib.metadata
 import os.path
 from dotenv import dotenv_values
 
@@ -26,7 +27,9 @@ DEFAULTS: dict[str, str] = {
                                     'prompt_templates', 'initial_prompt.txt'),
     'TIND_API_URL': 'https://digicoll.lib.berkeley.edu/api/v1',
     'SUMMARIZATION_MAX_TOKENS': '500',
-    'LANGFUSE_HOST': 'https://us.cloud.langfuse.com'
+    'LANGFUSE_HOST': 'https://us.cloud.langfuse.com',
+    'EXTRA_VERSION': '',
+    'DEPLOYMENT_ID': 'default'
 }
 """The defaults for configuration variables not set in the .env file."""
 
@@ -35,7 +38,8 @@ VALID_VARS: set[str] = {'TIND_API_KEY', 'TIND_API_URL', 'DEFAULT_STORAGE_DIR', '
                         'OLLAMA_URL', 'CHAT_MODEL', 'CHAT_TEMPERATURE', 'CALNET_ENV',
                         'CALNET_OIDC_CLIENT_ID', 'CALNET_OIDC_CLIENT_SECRET', 'LANCEDB_URI',
                         'CHAT_BACKEND', 'EMBED_BACKEND', 'LANGFUSE_HOST', 'LANGFUSE_PUBLIC_KEY',
-                        'LANGFUSE_SECRET_KEY', 'SUMMARIZATION_MAX_TOKENS'}
+                        'LANGFUSE_SECRET_KEY', 'SUMMARIZATION_MAX_TOKENS', 'EXTRA_VERSION',
+                        'DEPLOYMENT_ID'}
 """Valid configuration variables that could be in the environment."""
 
 
@@ -117,7 +121,9 @@ def get_model() -> BaseChatModel:
         )
     return model
 
+
 def get_langfuse_client() -> Langfuse:
     """Return a configured instance of the Langfuse client. Currently relies on
     Langfuse's environment variables."""
-    return Langfuse()
+    version = f"{importlib.metadata.version('willa')}{CONFIG['EXTRA_VERSION']}"
+    return Langfuse(release=version, environment=CONFIG['DEPLOYMENT_ID'])


### PR DESCRIPTION
This adds two environment variables, ``EXTRA_VERSION`` and ``DEPLOYMENT_ID``, which control what is shown in Langfuse.

Developers are encouraged to run Willa locally using ``bin/dev``, which will set the variables correctly and then start Compose.

The variables are not documented because they are not intended to be set manually or in the .env file.

Implements: AP-457