### PR TITLE
docker-compose: Use .env for most environment vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Copy environment file
+        run: cp env.example .env
+
       - name: Set ARTIFACTS_DIR
         run: echo "ARTIFACTS_DIR=${RUNNER_TEMP}/artifacts" >> $GITHUB_ENV
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,29 +28,9 @@ services:
     restart: always
     ports:
       - 8000:8000
+    env_file: .env
     environment:
       <<: *dbconfig
-      CALNET_OIDC_CLIENT_ID:
-      CALNET_OIDC_CLIENT_SECRET:
-      CHAINLIT_AUTH_SECRET:
-      DEFAULT_STORAGE_DIR:
-      LANCEDB_URI:
-      OLLAMA_URL:
-      AWS_ENDPOINT_URL:
-      AWS_ENDPOINT: ${AWS_ENDPOINT_URL}
-      AWS_ACCESS_KEY_ID:
-      AWS_SECRET_ACCESS_KEY:
-      AWS_DEFAULT_REGION:
-      ALLOW_HTTP:
-      CHAT_BACKEND:
-      CHAT_MODEL:
-      CHAT_TEMPERATURE:
-      EMBED_BACKEND:
-      EMBED_MODEL:
-      LANGFUSE_PUBLIC_KEY:
-      LANGFUSE_SECRET_KEY:
-      LANGFUSE_HOST:
-      SUMMARIZATION_MAX_TOKENS:
     volumes:
       - ./.data/lancedb:/lancedb
       - ./tmp:/pdfs


### PR DESCRIPTION
This is much cleaner, and easier to maintain, than keeping the whole list in the docker-compose.yml file.  The main reason we were doing that was to ensure we didn't leak unnecessary secrets into the Docker environment, but the secrets we *do* use there are of higher sensitivity anyway.  This eases maintenance burden and does not significantly impact security.

--

Reopening of #50, #56, with different branch name.