### PR TITLE
config: Specify Cohere as Bedrock embed provider

### DIFF
--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -113,7 +113,7 @@ def get_lance() -> LanceDB:
         embeddings: Embeddings = OllamaEmbeddings(model=CONFIG['EMBED_MODEL'],
                                                   base_url=CONFIG['OLLAMA_URL'])
     else:  # If we add another backend, elif CONFIG['EMBED_BACKEND'] == 'bedrock':
-        embeddings = BedrockEmbeddings(model_id=CONFIG['EMBED_MODEL'])
+        embeddings = BedrockEmbeddings(model_id=CONFIG['EMBED_MODEL'], provider='cohere')
     return LanceDB(embedding=embeddings, uri=CONFIG['LANCEDB_URI'], table_name='willa')
 
 


### PR DESCRIPTION
We will need to change this if we move off of Cohere embedding models. This helps the performance of the embeddings somewhat, as Langchain is then able to send multiple documents in a single API call.

Ref: AP-454