### PR TITLE
Docker: Use single target ``app`` for deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
           tags: ${{ steps.build-meta.outputs.tags }}
           provenance: true
           sbom: true
-          target: development
           cache-from: type=gha
           cache-to: type=gha
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ WORKDIR /app
 RUN apt-get update -y && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/
 
-COPY pyproject.toml pyproject.toml
-
 RUN python -m venv /venv
 ENV PATH=/venv/bin:$PATH
+ENV VIRTUAL_ENV=/venv
 RUN python -m pip install -U setuptools
-RUN pip install -q .
+
+COPY pyproject.toml pyproject.toml
+
+RUN pip install --no-cache-dir -q .[dev]
 
 FROM reqs AS app
 COPY willa willa
@@ -21,11 +23,7 @@ COPY CHANGELOG.rst CHANGELOG.rst
 COPY public public
 COPY chainlit.md chainlit.md
 COPY .chainlit .chainlit
-RUN pip install -e .
-
-ENV VIRTUAL_ENV=/venv
-CMD ["chainlit", "run", "/app/willa/web/app.py", "-h", "--host", "0.0.0.0"]
-
-FROM app AS development
 COPY tests tests
-RUN pip install -q .[dev]
+RUN pip install --no-cache-dir -e .
+
+CMD ["chainlit", "run", "/app/willa/web/app.py", "-h", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
   app:
     build:
       context: .
-      target: ${DOCKER_APP_BUILD_TARGET:-app}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This removes the ``development`` target which we were using to contain our extra development dependencies, combining it into the ``app`` target.

Note that this adds an additional ~300 MB to the image size right now; this will be addressed by AP-470.

Implements: AP-469