### PR TITLE
Thin dependencies significantly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,9 @@ jobs:
         working-directory: /app
     steps:
       - name: Run mypy
-        run: mypy .
+        run: |
+          pip3 install --no-cache-dir -e .[lint]
+          mypy .
 
   test-pydoclint:
     runs-on: ubuntu-24.04
@@ -130,7 +132,9 @@ jobs:
         working-directory: /app
     steps:
       - name: Run pydoclint
-        run: pydoclint .
+        run: |
+          pip3 install --no-cache-dir pydoclint
+          pydoclint .
 
   # pylint returns error codes if the checks fail
   # @see https://pylint.readthedocs.io/en/latest/user_guide/usage/run.html#exit-codes
@@ -144,7 +148,9 @@ jobs:
         working-directory: /app
     steps:
       - name: Run pylint
-        run: pylint -v .
+        run: |
+          pip3 install --no-cache-dir pylint
+          pylint -v .
 
   test-unit:
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "willa"
 version = "0.0.1"
 dependencies = [
-    "anthropic == 0.67.0", # for pydoclint incompatibility
     "asyncpg",
     "awscli-local",
     "boto3",
     "chainlit ~= 2.7.1",
     "lancedb",
-    "langchain",
     "langchain_aws",
-    "langchain_community",
+    "langchain_core",
     "langchain_ollama",
     "langfuse",
     "langgraph",
@@ -51,7 +49,7 @@ debug = [
     "debugpy",
 ]
 dev = [
-    "willa[test,lint,debug]"
+    "willa[test,debug]"
 ]
 
 [project.scripts]

--- a/willa/config/__init__.py
+++ b/willa/config/__init__.py
@@ -9,7 +9,6 @@ import os.path
 from dotenv import dotenv_values
 
 from langchain_aws import BedrockEmbeddings, ChatBedrockConverse
-from langchain_community.vectorstores import LanceDB
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
@@ -17,7 +16,9 @@ from langchain_ollama import ChatOllama, OllamaEmbeddings
 from langfuse import Langfuse
 from langfuse.api.resources.commons.errors.not_found_error import NotFoundError
 from langfuse.model import ChatPromptClient
+
 from willa.errors.config import ImproperConfigurationError
+from willa.lcvendor.lancedb import LanceDB
 
 # Prompt if langfuse defined prompt can't be set
 FALLBACK_PROMPT = """You are a reference librarian who helps researchers answer

--- a/willa/etl/doc_proc.py
+++ b/willa/etl/doc_proc.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Optional, Union
 from unittest.mock import MagicMock
 
-from langchain_community.document_loaders import PyPDFLoader, PyPDFDirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_core.documents import Document
 from langchain_core.vectorstores.base import VectorStore
@@ -20,6 +19,7 @@ from opentelemetry.util._decorator import _AgnosticContextManager
 from pymarc.record import Record
 
 from willa.config import CONFIG, get_langfuse_client
+from willa.lcvendor.pypdf import PyPDFLoader, PyPDFDirectoryLoader
 from willa.tind.format_validate_pymarc import pymarc_to_metadata
 
 

--- a/willa/lcvendor/LICENSE.txt
+++ b/willa/lcvendor/LICENSE.txt
@@ -1,0 +1,23 @@
+Upstream-URL: https://github.com/langchain-ai/langchain-community/
+
+MIT License
+
+Copyright (c) 2024 LangChain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/willa/lcvendor/__init__.py
+++ b/willa/lcvendor/__init__.py
@@ -1,0 +1,3 @@
+"""
+Vendored code from Langchain Community to reduce dependency bloat.
+"""

--- a/willa/lcvendor/lancedb.py
+++ b/willa/lcvendor/lancedb.py
@@ -1,0 +1,603 @@
+# pylint: skip-file
+
+import base64
+import os
+import uuid
+import warnings
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from langchain_core.utils import guard_import
+from langchain_core.vectorstores import VectorStore
+
+DEFAULT_K = 4  # Number of Documents to return.
+
+
+def import_lancedb() -> Any:
+    """Import lancedb package."""
+    return guard_import("lancedb")
+
+
+def to_lance_filter(filter: Dict[str, str]) -> str:
+    """Converts a dict filter to a LanceDB filter string."""
+    return " AND ".join([f"{k} = '{v}'" for k, v in filter.items()])
+
+
+class LanceDB(VectorStore):
+    """`LanceDB` vector store.
+
+    To use, you should have ``lancedb`` python package installed.
+    You can install it with ``pip install lancedb``.
+
+    Args:
+        connection: LanceDB connection to use. If not provided, a new connection
+                    will be created.
+        embedding: Embedding to use for the vectorstore.
+        vector_key: Key to use for the vector in the database. Defaults to ``vector``.
+        id_key: Key to use for the id in the database. Defaults to ``id``.
+        text_key: Key to use for the text in the database. Defaults to ``text``.
+        table_name: Name of the table to use. Defaults to ``vectorstore``.
+        api_key: API key to use for LanceDB cloud database.
+        region: Region to use for LanceDB cloud database.
+        mode: Mode to use for adding data to the table. Valid values are
+              ``append`` and ``overwrite``. Defaults to ``overwrite``.
+
+
+
+    Example:
+        .. code-block:: python
+            vectorstore = LanceDB(uri='/lancedb', embedding_function)
+            vectorstore.add_texts(['text1', 'text2'])
+            result = vectorstore.similarity_search('text1')
+    """
+
+    def __init__(
+        self,
+        connection: Optional[Any] = None,
+        embedding: Optional[Embeddings] = None,
+        uri: Optional[str] = "/tmp/lancedb",
+        vector_key: Optional[str] = "vector",
+        id_key: Optional[str] = "id",
+        text_key: Optional[str] = "text",
+        table_name: Optional[str] = "vectorstore",
+        api_key: Optional[str] = None,
+        region: Optional[str] = None,
+        mode: Optional[str] = "overwrite",
+        table: Optional[Any] = None,
+        distance: Optional[str] = "l2",
+        reranker: Optional[Any] = None,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
+        limit: int = DEFAULT_K,
+    ):
+        """Initialize with Lance DB vectorstore"""
+        lancedb = guard_import("lancedb")
+        lancedb.remote.table = guard_import("lancedb.remote.table")
+        self._embedding = embedding
+        self._vector_key = vector_key
+        self._id_key = id_key
+        self._text_key = text_key
+        self.api_key = api_key or os.getenv("LANCE_API_KEY") if api_key != "" else None
+        self.region = region
+        self.mode = mode
+        self.distance = distance
+        self.override_relevance_score_fn = relevance_score_fn
+        self.limit = limit
+        self._fts_index = None
+
+        if isinstance(reranker, lancedb.rerankers.Reranker):
+            self._reranker = reranker
+        elif reranker is None:
+            self._reranker = None
+        else:
+            raise ValueError(
+                "`reranker` has to be a lancedb.rerankers.Reranker object."
+            )
+
+        if isinstance(uri, str) and self.api_key is None:
+            if uri.startswith("db://"):
+                raise ValueError("API key is required for LanceDB cloud.")
+
+        if self._embedding is None:
+            raise ValueError("embedding object should be provided")
+
+        if isinstance(connection, lancedb.db.LanceDBConnection):
+            self._connection = connection
+        elif isinstance(connection, (str, lancedb.db.LanceTable)):
+            raise ValueError(
+                "`connection` has to be a lancedb.db.LanceDBConnection object.\
+                `lancedb.db.LanceTable` is deprecated."
+            )
+        else:
+            if self.api_key is None:
+                self._connection = lancedb.connect(uri)
+            else:
+                if isinstance(uri, str):
+                    if uri.startswith("db://"):
+                        self._connection = lancedb.connect(
+                            uri, api_key=self.api_key, region=self.region
+                        )
+                    else:
+                        self._connection = lancedb.connect(uri)
+                        warnings.warn(
+                            "api key provided with local uri.\
+                            The data will be stored locally"
+                        )
+        if table is not None:
+            try:
+                assert isinstance(
+                    table, (lancedb.db.LanceTable, lancedb.remote.table.RemoteTable)
+                )
+                self._table = table
+                self._table_name = (
+                    table.name if hasattr(table, "name") else "remote_table"
+                )
+            except AssertionError:
+                raise ValueError(
+                    """`table` has to be a lancedb.db.LanceTable or 
+                    lancedb.remote.table.RemoteTable object."""
+                )
+        else:
+            self._table = self.get_table(table_name, set_default=True)
+
+    def results_to_docs(self, results: Any, score: bool = False) -> Any:
+        columns = results.schema.names
+
+        if "_distance" in columns:
+            score_col = "_distance"
+        elif "_relevance_score" in columns:
+            score_col = "_relevance_score"
+        else:
+            score_col = None
+        # Check if 'metadata' is in the columns
+        has_metadata = "metadata" in columns
+
+        if score_col is None or not score:
+            return [
+                Document(
+                    page_content=results[self._text_key][idx].as_py(),
+                    metadata=results["metadata"][idx].as_py() if has_metadata else {},
+                )
+                for idx in range(len(results))
+            ]
+        elif score_col and score:
+            return [
+                (
+                    Document(
+                        page_content=results[self._text_key][idx].as_py(),
+                        metadata=results["metadata"][idx].as_py()
+                        if has_metadata
+                        else {},
+                    ),
+                    results[score_col][idx].as_py(),
+                )
+                for idx in range(len(results))
+            ]
+
+    @property
+    def embeddings(self) -> Optional[Embeddings]:
+        return self._embedding
+
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Turn texts into embedding and add it to the database
+
+        Args:
+            texts: Iterable of strings to add to the vectorstore.
+            metadatas: Optional list of metadatas associated with the texts.
+            ids: Optional list of ids to associate with the texts.
+            ids: Optional list of ids to associate with the texts.
+
+        Returns:
+            List of ids of the added texts.
+        """
+        docs = []
+        ids = ids or [str(uuid.uuid4()) for _ in texts]
+        embeddings = self._embedding.embed_documents(list(texts))  # type: ignore[union-attr]
+        for idx, text in enumerate(texts):
+            embedding = embeddings[idx]
+            metadata = metadatas[idx] if metadatas else {"id": ids[idx]}
+            docs.append(
+                {
+                    self._vector_key: embedding,
+                    self._id_key: ids[idx],
+                    self._text_key: text,
+                    "metadata": metadata,
+                }
+            )
+
+        tbl = self.get_table()
+
+        if tbl is None:
+            tbl = self._connection.create_table(self._table_name, data=docs)
+            self._table = tbl
+        else:
+            if self.api_key is None:
+                tbl.add(docs, mode=self.mode)
+            else:
+                tbl.add(docs)
+
+        self._fts_index = None
+
+        return ids
+
+    def get_table(
+        self, name: Optional[str] = None, set_default: Optional[bool] = False
+    ) -> Any:
+        """
+        Fetches a table object from the database.
+
+        Args:
+            name (str, optional): The name of the table to fetch. Defaults to None
+                                    and fetches current table object.
+            set_default (bool, optional): Sets fetched table as the default table.
+                                        Defaults to False.
+
+        Returns:
+            Any: The fetched table object.
+
+        Raises:
+            ValueError: If the specified table is not found in the database.
+
+        """
+        if name is not None:
+            if set_default:
+                self._table_name = name
+                _name = self._table_name
+            else:
+                _name = name
+        else:
+            _name = self._table_name
+
+        try:
+            return self._connection.open_table(_name)
+        except Exception:
+            return None
+
+    def create_index(
+        self,
+        col_name: Optional[str] = None,
+        vector_col: Optional[str] = None,
+        num_partitions: Optional[int] = 256,
+        num_sub_vectors: Optional[int] = 96,
+        index_cache_size: Optional[int] = None,
+        metric: Optional[str] = "L2",
+        name: Optional[str] = None,
+    ) -> None:
+        """
+        Create a scalar(for non-vector cols) or a vector index on a table.
+        Make sure your vector column has enough data before creating an index on it.
+
+        Args:
+            vector_col: Provide if you want to create index on a vector column.
+            col_name: Provide if you want to create index on a non-vector column.
+            metric: Provide the metric to use for vector index. Defaults to 'L2'
+                    choice of metrics: 'L2', 'dot', 'cosine'
+            num_partitions: Number of partitions to use for the index. Defaults to 256.
+            num_sub_vectors: Number of sub-vectors to use for the index. Defaults to 96.
+            index_cache_size: Size of the index cache. Defaults to None.
+            name: Name of the table to create index on. Defaults to None.
+
+        Returns:
+            None
+        """
+        tbl = self.get_table(name)
+
+        if vector_col:
+            tbl.create_index(
+                metric=metric,
+                vector_column_name=vector_col,
+                num_partitions=num_partitions,
+                num_sub_vectors=num_sub_vectors,
+                index_cache_size=index_cache_size,
+            )
+        elif col_name:
+            tbl.create_scalar_index(col_name)
+        else:
+            raise ValueError("Provide either vector_col or col_name")
+
+    def encode_image(self, uri: str) -> str:
+        """Get base64 string from image URI."""
+        with open(uri, "rb") as image_file:
+            return base64.b64encode(image_file.read()).decode("utf-8")
+
+    def add_images(
+        self,
+        uris: List[str],
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Run more images through the embeddings and add to the vectorstore.
+
+        Args:
+            uris List[str]: File path to the image.
+            metadatas (Optional[List[dict]], optional): Optional list of metadatas.
+            ids (Optional[List[str]], optional): Optional list of IDs.
+
+        Returns:
+            List[str]: List of IDs of the added images.
+        """
+        tbl = self.get_table()
+
+        # Map from uris to b64 encoded strings
+        b64_texts = [self.encode_image(uri=uri) for uri in uris]
+        # Populate IDs
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in uris]
+        embeddings = None
+        # Set embeddings
+        if self._embedding is not None and hasattr(self._embedding, "embed_image"):
+            embeddings = self._embedding.embed_image(uris=uris)
+        else:
+            raise ValueError(
+                "embedding object should be provided and must have embed_image method."
+            )
+
+        data = []
+        for idx, emb in enumerate(embeddings):
+            metadata = metadatas[idx] if metadatas else {"id": ids[idx]}
+            data.append(
+                {
+                    self._vector_key: emb,
+                    self._id_key: ids[idx],
+                    self._text_key: b64_texts[idx],
+                    "metadata": metadata,
+                }
+            )
+        if tbl is None:
+            tbl = self._connection.create_table(self._table_name, data=data)
+            self._table = tbl
+        else:
+            tbl.add(data)
+
+        return ids
+
+    def _query(
+        self,
+        query: Any,
+        k: Optional[int] = None,
+        filter: Optional[Any] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if k is None:
+            k = self.limit
+        tbl = self.get_table(name)
+        if isinstance(filter, dict):
+            filter = to_lance_filter(filter)
+
+        prefilter = kwargs.get("prefilter", False)
+        query_type = kwargs.get("query_type", "vector")
+
+        if metrics := kwargs.get("metrics"):
+            lance_query = (
+                tbl.search(query=query, vector_column_name=self._vector_key)
+                .limit(k)
+                .metric(metrics)
+                .where(filter, prefilter=prefilter)
+            )
+        else:
+            lance_query = (
+                tbl.search(query=query, vector_column_name=self._vector_key)
+                .limit(k)
+                .where(filter, prefilter=prefilter)
+            )
+        if query_type == "hybrid" and self._reranker is not None:
+            lance_query.rerank(reranker=self._reranker)
+
+        docs = lance_query.to_arrow()
+        if len(docs) == 0:
+            warnings.warn("No results found for the query.")
+        return docs
+
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        """
+        The 'correct' relevance function
+        may differ depending on a few things, including:
+        - the distance / similarity metric used by the VectorStore
+        - the scale of your embeddings (OpenAI's are unit normed. Many others are not!)
+        - embedding dimensionality
+        - etc.
+        """
+        if self.override_relevance_score_fn:
+            return self.override_relevance_score_fn
+
+        if self.distance == "cosine":
+            return self._cosine_relevance_score_fn
+        elif self.distance == "l2":
+            return self._euclidean_relevance_score_fn
+        elif self.distance == "ip":
+            return self._max_inner_product_relevance_score_fn
+        else:
+            raise ValueError(
+                "No supported normalization function"
+                f" for distance metric of type: {self.distance}."
+                "Consider providing relevance_score_fn to Chroma constructor."
+            )
+
+    def similarity_search_by_vector(
+        self,
+        embedding: List[float],
+        k: Optional[int] = None,
+        filter: Optional[Dict[str, str]] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Return documents most similar to the query vector.
+        """
+        if k is None:
+            k = self.limit
+
+        res = self._query(embedding, k, filter=filter, name=name, **kwargs)
+        return self.results_to_docs(res, score=kwargs.pop("score", False))
+
+    def similarity_search_by_vector_with_relevance_scores(
+        self,
+        embedding: List[float],
+        k: Optional[int] = None,
+        filter: Optional[Dict[str, str]] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Return documents most similar to the query vector with relevance scores.
+        """
+        if k is None:
+            k = self.limit
+
+        relevance_score_fn = self._select_relevance_score_fn()
+        docs_and_scores = self.similarity_search_by_vector(
+            embedding, k, score=True, **kwargs
+        )
+        return [
+            (doc, relevance_score_fn(float(score))) for doc, score in docs_and_scores
+        ]
+
+    def similarity_search_with_score(
+        self,
+        query: str,
+        k: Optional[int] = None,
+        filter: Optional[Dict[str, str]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Return documents most similar to the query with relevance scores."""
+        if k is None:
+            k = self.limit
+
+        score = kwargs.get("score", True)
+        name = kwargs.get("name", None)
+        query_type = kwargs.get("query_type", "vector")
+
+        if self._embedding is None:
+            raise ValueError("search needs an embedding function to be specified.")
+
+        if query_type == "fts" or query_type == "hybrid":
+            if self.api_key is None and self._fts_index is None:
+                tbl = self.get_table(name)
+                self._fts_index = tbl.create_fts_index(self._text_key, replace=True)
+
+                if query_type == "hybrid":
+                    embedding = self._embedding.embed_query(query)
+                    _query = (embedding, query)
+                else:
+                    _query = query  # type: ignore[assignment]
+
+                res = self._query(_query, k, filter=filter, name=name, **kwargs)
+                return self.results_to_docs(res, score=score)
+            else:
+                raise NotImplementedError(
+                    "Full text/ Hybrid search is not supported in LanceDB Cloud yet."
+                )
+        else:
+            embedding = self._embedding.embed_query(query)
+            res = self._query(embedding, k, filter=filter, **kwargs)
+            return self.results_to_docs(res, score=score)
+
+    def similarity_search(
+        self,
+        query: str,
+        k: Optional[int] = None,
+        name: Optional[str] = None,
+        filter: Optional[Any] = None,
+        fts: Optional[bool] = False,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return documents most similar to the query
+
+        Args:
+            query: String to query the vectorstore with.
+            k: Number of documents to return.
+            filter (Optional[Dict]): Optional filter arguments
+                sql_filter(Optional[string]): SQL filter to apply to the query.
+                prefilter(Optional[bool]): Whether to apply the filter prior
+                                             to the vector search.
+        Raises:
+            ValueError: If the specified table is not found in the database.
+
+        Returns:
+            List of documents most similar to the query.
+        """
+        res: list[Document] = self.similarity_search_with_score(
+            query=query, k=k, name=name, filter=filter, fts=fts, score=False, **kwargs
+        )
+        return res
+
+    @classmethod
+    def from_texts(
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        connection: Optional[Any] = None,
+        vector_key: Optional[str] = "vector",
+        id_key: Optional[str] = "id",
+        text_key: Optional[str] = "text",
+        table_name: Optional[str] = "vectorstore",
+        api_key: Optional[str] = None,
+        region: Optional[str] = None,
+        mode: Optional[str] = "overwrite",
+        distance: Optional[str] = "l2",
+        reranker: Optional[Any] = None,
+        relevance_score_fn: Optional[Callable[[float], float]] = None,
+        **kwargs: Any,
+    ) -> "LanceDB":
+        instance = LanceDB(
+            connection=connection,
+            embedding=embedding,
+            vector_key=vector_key,
+            id_key=id_key,
+            text_key=text_key,
+            table_name=table_name,
+            api_key=api_key,
+            region=region,
+            mode=mode,
+            distance=distance,
+            reranker=reranker,
+            relevance_score_fn=relevance_score_fn,
+            **kwargs,
+        )
+        instance.add_texts(texts, metadatas=metadatas)
+
+        return instance
+
+    def delete(
+        self,
+        ids: Optional[List[str]] = None,
+        delete_all: Optional[bool] = None,
+        filter: Optional[str] = None,
+        drop_columns: Optional[List[str]] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Allows deleting rows by filtering, by ids or drop columns from the table.
+
+        Args:
+            filter: Provide a string SQL expression -  "{col} {operation} {value}".
+            ids: Provide list of ids to delete from the table.
+            drop_columns: Provide list of columns to drop from the table.
+            delete_all: If True, delete all rows from the table.
+        """
+        tbl = self.get_table(name)
+        if filter:
+            tbl.delete(filter)
+        elif ids:
+            tbl.delete(f"{self._id_key} in ('{{}}')".format(",".join(ids)))
+        elif drop_columns:
+            if self.api_key is not None:
+                raise NotImplementedError(
+                    "Column operations currently not supported in LanceDB Cloud."
+                )
+            else:
+                tbl.drop_columns(drop_columns)
+        elif delete_all:
+            tbl.delete("true")
+        else:
+            raise ValueError("Provide either filter, ids, drop_columns or delete_all")

--- a/willa/lcvendor/pypdf.py
+++ b/willa/lcvendor/pypdf.py
@@ -1,0 +1,858 @@
+# pylint: skip-file
+
+import html
+import io
+import logging
+import os
+import re
+import tempfile
+from abc import ABC, abstractmethod
+from datetime import datetime
+from pathlib import Path, PurePath
+from typing import (
+    Any,
+    Iterator,
+    Literal,
+    Optional,
+    Union,
+    cast,
+)
+from urllib.parse import urlparse
+
+import pypdf
+import requests
+from langchain_core.documents import Document
+from langchain_core.document_loaders import BaseBlobParser, BaseLoader, Blob
+
+logger = logging.getLogger(__file__)
+
+_FORMAT_IMAGE_STR = "\n\n{image_text}\n\n"
+_JOIN_IMAGES = "\n"
+_JOIN_TABLES = "\n"
+_DEFAULT_PAGES_DELIMITER = "\n\f"
+
+_STD_METADATA_KEYS = {"source", "total_pages", "creationdate", "creator", "producer"}
+_PDF_FILTER_WITH_LOSS = ["DCTDecode", "DCT", "JPXDecode"]
+_PDF_FILTER_WITHOUT_LOSS = [
+    "LZWDecode",
+    "LZW",
+    "FlateDecode",
+    "Fl",
+    "ASCII85Decode",
+    "A85",
+    "ASCIIHexDecode",
+    "AHx",
+    "RunLengthDecode",
+    "RL",
+    "CCITTFaxDecode",
+    "CCF",
+    "JBIG2Decode",
+]
+
+
+def _format_inner_image(blob: Blob, content: str, format: str) -> str:
+    """Format the content of the image with the source of the blob.
+
+    blob: The blob containing the image.
+    format::
+      The format for the parsed output.
+      - "text" = return the content as is
+      - "markdown-img" = wrap the content into an image Markdown link, w/ link
+      pointing to (`![body)(#)`]
+      - "html-img" = wrap the content as the `alt` text of a tag and link to
+      (`<img alt="{body}" src="#"/>`)
+    """
+    if content:
+        source = blob.source or "#"
+        if format == "markdown-img":
+            content = content.replace("]", r"\\]")
+            content = f"![{content}]({source})"
+        elif format == "html-img":
+            content = f'<img alt="{html.escape(content, quote=True)} src="{source}" />'
+    return content
+
+
+def _validate_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Validate that the metadata has all the standard keys and the page is an integer.
+
+    The standard keys are:
+    - source
+    - total_page
+    - creationdate
+    - creator
+    - producer
+
+    Validate that page is an integer if it is present.
+    """
+    if not _STD_METADATA_KEYS.issubset(metadata.keys()):
+        raise ValueError("The PDF parser must valorize the standard metadata.")
+    if not isinstance(metadata.get("page", 0), int):
+        raise ValueError("The PDF metadata page must be a integer.")
+    return metadata
+
+
+def _purge_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Purge metadata from unwanted keys and normalize key names.
+
+    Args:
+        metadata: The original metadata dictionary.
+
+    Returns:
+        The cleaned and normalized the key format of metadata dictionary.
+    """
+    new_metadata: dict[str, Any] = {}
+    map_key = {
+        "page_count": "total_pages",
+        "file_path": "source",
+    }
+    for k, v in metadata.items():
+        if type(v) not in [str, int]:
+            v = str(v)
+        if k.startswith("/"):
+            k = k[1:]
+        k = k.lower()
+        if k in ["creationdate", "moddate"]:
+            try:
+                new_metadata[k] = datetime.strptime(
+                    v.replace("'", ""), "D:%Y%m%d%H%M%S%z"
+                ).isoformat("T")
+            except ValueError:
+                new_metadata[k] = v
+        elif k in map_key:
+            # Normalize key with others PDF parser
+            new_metadata[map_key[k]] = v
+            new_metadata[k] = v
+        elif isinstance(v, str):
+            new_metadata[k] = v.strip()
+        elif isinstance(v, int):
+            new_metadata[k] = v
+    return new_metadata
+
+
+_PARAGRAPH_DELIMITER = [
+    "\n\n\n",
+    "\n\n",
+]  # To insert images or table in the middle of the page.
+
+
+def _merge_text_and_extras(extras: list[str], text_from_page: str) -> str:
+    """Insert extras such as image/table in a text between two paragraphs if possible,
+    else at the end of the text.
+
+    Args:
+        extras: List of extra content (images/tables) to insert.
+        text_from_page: The text content from the page.
+
+    Returns:
+        The merged text with extras inserted.
+    """
+
+    def _recurs_merge_text_and_extras(
+        extras: list[str], text_from_page: str, recurs: bool
+    ) -> Optional[str]:
+        if extras:
+            for delim in _PARAGRAPH_DELIMITER:
+                pos = text_from_page.rfind(delim)
+                if pos != -1:
+                    # search penultimate, to bypass an error in footer
+                    previous_text = None
+                    if recurs:
+                        previous_text = _recurs_merge_text_and_extras(
+                            extras, text_from_page[:pos], False
+                        )
+                    if previous_text:
+                        all_text = previous_text + text_from_page[pos:]
+                    else:
+                        all_extras = ""
+                        str_extras = "\n\n".join(filter(lambda x: x, extras))
+                        if str_extras:
+                            all_extras = delim + str_extras
+                        all_text = (
+                            text_from_page[:pos] + all_extras + text_from_page[pos:]
+                        )
+                    break
+            else:
+                all_text = None
+        else:
+            all_text = text_from_page
+        return all_text
+
+    all_text = _recurs_merge_text_and_extras(extras, text_from_page, True)
+    if not all_text:
+        all_extras = ""
+        str_extras = "\n\n".join(filter(lambda x: x, extras))
+        if str_extras:
+            all_extras = _PARAGRAPH_DELIMITER[-1] + str_extras
+        all_text = text_from_page + all_extras
+
+    return all_text
+
+
+class BaseImageBlobParser(BaseBlobParser):
+    """Abstract base class for parsing image blobs into text."""
+
+    @abstractmethod
+    def _analyze_image(self, img: Any) -> str:
+        """Abstract method to analyze an image and extract textual content.
+
+        Args:
+            img: The image to be analyzed.
+
+        Returns:
+          The extracted text content.
+        """
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:
+        """Lazily parse a blob and yields Documents containing the parsed content.
+
+        Args:
+            blob (Blob): The blob to be parsed.
+
+        Yields:
+            Document:
+              A document containing the parsed content and metadata.
+        """
+        try:
+            import numpy
+            from PIL import Image as Img  # type: ignore[import-not-found]
+        except ImportError:
+            raise ImportError(
+                "`Pillow` package not found, please install it with "
+                "`pip install Pillow`"
+            )
+
+        with blob.as_bytes_io() as buf:
+            if blob.mimetype == "application/x-npy":
+                array = numpy.load(buf)
+                if array.ndim == 3 and array.shape[2] == 1:  # Grayscale image
+                    img = Img.fromarray(numpy.squeeze(array, axis=2), mode="L")
+                else:
+                    img = Img.fromarray(array)
+            else:
+                img = Img.open(buf)
+            content = self._analyze_image(img)
+            logger.debug("Image text: %s", content.replace("\n", "\\n"))
+            yield Document(
+                page_content=content,
+                metadata={**blob.metadata, **{"source": blob.source}},
+            )
+
+
+class RapidOCRBlobParser(BaseImageBlobParser):
+    """Parser for extracting text from images using the RapidOCR library.
+
+    Attributes:
+        ocr:
+          The RapidOCR instance for performing OCR.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initializes the RapidOCRBlobParser.
+        """
+        super().__init__()
+        self.ocr = None
+
+    def _analyze_image(self, img: Any) -> str:
+        """
+        Analyzes an image and extracts text using RapidOCR.
+
+        Args:
+            img (Image):
+              The image to be analyzed.
+
+        Returns:
+            str:
+              The extracted text content.
+        """
+        if not self.ocr:
+            try:
+                from rapidocr_onnxruntime import RapidOCR  # type: ignore[import-not-found]
+
+                self.ocr = RapidOCR()
+            except ImportError:
+                raise ImportError(
+                    "`rapidocr-onnxruntime` package not found, please install it with "
+                    "`pip install rapidocr-onnxruntime`"
+                )
+        ocr_result, _ = self.ocr(np.array(img))  # type: ignore[misc,name-defined]
+        content = ""
+        if ocr_result:
+            content = ("\n".join([text[1] for text in ocr_result])).strip()
+        return content
+
+
+class PyPDFParser(BaseBlobParser):
+    """Parse a blob from a PDF using `pypdf` library.
+
+    This class provides methods to parse a blob from a PDF document, supporting various
+    configurations such as handling password-protected PDFs, extracting images.
+    It integrates the 'pypdf' library for PDF processing and offers synchronous blob
+    parsing.
+
+    Examples:
+        Setup:
+
+        .. code-block:: bash
+
+            pip install -U langchain-community pypdf
+
+        Load a blob from a PDF file:
+
+        .. code-block:: python
+
+            from langchain_core.documents.base import Blob
+
+            blob = Blob.from_path("./example_data/layout-parser-paper.pdf")
+
+        Instantiate the parser:
+
+        .. code-block:: python
+
+            from langchain_community.document_loaders.parsers import PyPDFParser
+
+            parser = PyPDFParser(
+                # password = None,
+                mode = "single",
+                pages_delimiter = "\n\f",
+                # images_parser = TesseractBlobParser(),
+            )
+
+        Lazily parse the blob:
+
+        .. code-block:: python
+
+            docs = []
+            docs_lazy = parser.lazy_parse(blob)
+
+            for doc in docs_lazy:
+                docs.append(doc)
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+    """
+
+    def __init__(
+        self,
+        password: Optional[Union[str, bytes]] = None,
+        extract_images: bool = False,
+        *,
+        mode: Literal["single", "page"] = "page",
+        pages_delimiter: str = _DEFAULT_PAGES_DELIMITER,
+        images_parser: Optional[BaseImageBlobParser] = None,
+        images_inner_format: Literal["text", "markdown-img", "html-img"] = "text",
+        extraction_mode: Literal["plain", "layout"] = "plain",
+        extraction_kwargs: Optional[dict[str, Any]] = None,
+    ):
+        """Initialize a parser based on PyPDF.
+
+        Args:
+            password: Optional password for opening encrypted PDFs.
+            extract_images: Whether to extract images from the PDF.
+            mode: The extraction mode, either "single" for the entire document or "page"
+                for page-wise extraction.
+            pages_delimiter: A string delimiter to separate pages in single-mode
+                extraction.
+            images_parser: Optional image blob parser.
+            images_inner_format: The format for the parsed output.
+                - "text" = return the content as is
+                - "markdown-img" = wrap the content into an image markdown link, w/ link
+                pointing to (`![body)(#)`]
+                - "html-img" = wrap the content as the `alt` text of an tag and link to
+                (`<img alt="{body}" src="#"/>`)
+            extraction_mode: “plain” for legacy functionality, “layout” extract text
+                in a fixed width format that closely adheres to the rendered layout in
+                the source pdf.
+            extraction_kwargs: Optional additional parameters for the extraction
+                process.
+
+        Raises:
+            ValueError: If the `mode` is not "single" or "page".
+        """
+        super().__init__()
+        if mode not in ["single", "page"]:
+            raise ValueError("mode must be single or page")
+        self.extract_images = extract_images
+        if extract_images and not images_parser:
+            images_parser = RapidOCRBlobParser()
+        self.images_parser = images_parser
+        self.images_inner_format = images_inner_format
+        self.password = password
+        self.mode = mode
+        self.pages_delimiter = pages_delimiter
+        self.extraction_mode = extraction_mode
+        self.extraction_kwargs = extraction_kwargs or {}
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:
+        """
+        Lazily parse the blob.
+        Insert image, if possible, between two paragraphs.
+        In this way, a paragraph can be continued on the next page.
+
+        Args:
+            blob: The blob to parse.
+
+        Raises:
+            ImportError: If the `pypdf` package is not found.
+
+        Yield:
+            An iterator over the parsed documents.
+        """
+        try:
+            import pypdf
+        except ImportError:
+            raise ImportError(
+                "`pypdf` package not found, please install it with `pip install pypdf`"
+            )
+
+        def _extract_text_from_page(page: pypdf.PageObject) -> str:
+            """
+            Extract text from image given the version of pypdf.
+
+            Args:
+                page: The page object to extract text from.
+
+            Returns:
+                str: The extracted text.
+            """
+            if pypdf.__version__.startswith("3"):
+                return page.extract_text()
+            else:
+                return page.extract_text(
+                    extraction_mode=self.extraction_mode,
+                    **self.extraction_kwargs,
+                )
+
+        with blob.as_bytes_io() as pdf_file_obj:
+            pdf_reader = pypdf.PdfReader(pdf_file_obj, password=self.password)
+
+            doc_metadata = _purge_metadata(
+                {"producer": "PyPDF", "creator": "PyPDF", "creationdate": ""}
+                | cast(dict, pdf_reader.metadata or {})
+                | {
+                    "source": blob.source,
+                    "total_pages": len(pdf_reader.pages),
+                }
+            )
+            single_texts = []
+            for page_number, page in enumerate(pdf_reader.pages):
+                text_from_page = _extract_text_from_page(page=page)
+                images_from_page = self.extract_images_from_page(page)
+                all_text = _merge_text_and_extras(
+                    [images_from_page], text_from_page
+                ).strip()
+                if self.mode == "page":
+                    yield Document(
+                        page_content=all_text,
+                        metadata=_validate_metadata(
+                            doc_metadata
+                            | {
+                                "page": page_number,
+                                "page_label": pdf_reader.page_labels[page_number],
+                            }
+                        ),
+                    )
+                else:
+                    single_texts.append(all_text)
+            if self.mode == "single":
+                yield Document(
+                    page_content=self.pages_delimiter.join(single_texts),
+                    metadata=_validate_metadata(doc_metadata),
+                )
+
+    def extract_images_from_page(self, page: pypdf._page.PageObject) -> str:
+        """Extract images from a PDF page and get the text using images_to_text.
+
+        Args:
+            page: The page object from which to extract images.
+
+        Returns:
+            str: The extracted text from the images on the page.
+        """
+        if not self.images_parser:
+            return ""
+        import numpy as np
+        import pypdf
+        from PIL import Image
+
+        if "/XObject" not in cast(dict, page["/Resources"]).keys():
+            return ""
+
+        xObject = cast(dict, page["/Resources"])["/XObject"].get_object()
+        images = []
+        for obj in xObject:
+            np_image: Any = None
+            if xObject[obj]["/Subtype"] == "/Image":
+                img_filter = (
+                    xObject[obj]["/Filter"][1:]
+                    if type(xObject[obj]["/Filter"]) is pypdf.generic._base.NameObject
+                    else xObject[obj]["/Filter"][0][1:]
+                )
+                if img_filter in _PDF_FILTER_WITHOUT_LOSS:
+                    height, width = xObject[obj]["/Height"], xObject[obj]["/Width"]
+
+                    np_image = np.frombuffer(
+                        xObject[obj].get_data(), dtype=np.uint8
+                    ).reshape(height, width, -1)
+                elif img_filter in _PDF_FILTER_WITH_LOSS:
+                    np_image = np.array(Image.open(io.BytesIO(xObject[obj].get_data())))
+
+                else:
+                    logger.warning("Unknown PDF Filter!")
+                if np_image is not None:
+                    image_bytes = io.BytesIO()
+
+                    if image_bytes.getbuffer().nbytes == 0:
+                        continue
+
+                    Image.fromarray(np_image).save(image_bytes, format="PNG")
+                    blob = Blob.from_data(image_bytes.getvalue(), mime_type="image/png")
+                    image_text = next(self.images_parser.lazy_parse(blob)).page_content
+                    images.append(
+                        _format_inner_image(blob, image_text, self.images_inner_format)
+                    )
+        return _FORMAT_IMAGE_STR.format(
+            image_text=_JOIN_IMAGES.join(filter(None, images))
+        )
+
+
+class BasePDFLoader(BaseLoader, ABC):
+    """Base Loader class for `PDF` files.
+
+    If the file is a web path, it will download it to a temporary file, use it, then
+        clean up the temporary file after completion.
+    """
+
+    def __init__(
+        self, file_path: Union[str, PurePath], *, headers: Optional[dict] = None
+    ):
+        """Initialize with a file path.
+
+        Args:
+            file_path: Either a local, S3 or web path to a PDF file.
+            headers: Headers to use for GET request to download a file from a web path.
+        """
+        self.file_path = str(file_path)
+        self.web_path = None
+        self.headers = headers
+        if "~" in self.file_path:
+            self.file_path = os.path.expanduser(self.file_path)
+
+        # If the file is a web path or S3, download it to a temporary file,
+        # and use that. It's better to use a BlobLoader.
+        if not os.path.isfile(self.file_path) and self._is_valid_url(self.file_path):
+            self.temp_dir = tempfile.TemporaryDirectory()
+            _, suffix = os.path.splitext(self.file_path)
+            if self._is_s3_presigned_url(self.file_path):
+                suffix = urlparse(self.file_path).path.split("/")[-1]
+            temp_pdf = os.path.join(self.temp_dir.name, f"tmp{suffix}")
+            self.web_path = self.file_path
+            if not self._is_s3_url(self.file_path):
+                r = requests.get(self.file_path, headers=self.headers)
+                if r.status_code != 200:
+                    raise ValueError(
+                        "Check the url of your file; returned status code %s"
+                        % r.status_code
+                    )
+
+                with open(temp_pdf, mode="wb") as f:
+                    f.write(r.content)
+                self.file_path = str(temp_pdf)
+        elif not os.path.isfile(self.file_path):
+            raise ValueError("File path %s is not a valid file or url" % self.file_path)
+
+    def __del__(self) -> None:
+        if hasattr(self, "temp_dir"):
+            self.temp_dir.cleanup()
+
+    @staticmethod
+    def _is_valid_url(url: str) -> bool:
+        """Check if the url is valid."""
+        parsed = urlparse(url)
+        return bool(parsed.netloc) and bool(parsed.scheme)
+
+    @staticmethod
+    def _is_s3_url(url: str) -> bool:
+        """check if the url is S3"""
+        try:
+            result = urlparse(url)
+            if result.scheme == "s3" and result.netloc:
+                return True
+            return False
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _is_s3_presigned_url(url: str) -> bool:
+        """Check if the url is a presigned S3 url."""
+        try:
+            result = urlparse(url)
+            return bool(re.search(r"\.s3\.amazonaws\.com$", result.netloc))
+        except ValueError:
+            return False
+
+    @property
+    def source(self) -> str:
+        return self.web_path if self.web_path is not None else self.file_path
+
+
+class PyPDFLoader(BasePDFLoader):
+    """Load and parse a PDF file using 'pypdf' library.
+
+    This class provides methods to load and parse PDF documents, supporting various
+    configurations such as handling password-protected files, extracting images, and
+    defining extraction mode. It integrates the `pypdf` library for PDF processing and
+    offers both synchronous and asynchronous document loading.
+
+    Examples:
+        Setup:
+
+        .. code-block:: bash
+
+            pip install -U langchain-community pypdf
+
+        Instantiate the loader:
+
+        .. code-block:: python
+
+            from langchain_community.document_loaders import PyPDFLoader
+
+            loader = PyPDFLoader(
+                file_path = "./example_data/layout-parser-paper.pdf",
+                # headers = None
+                # password = None,
+                mode = "single",
+                pages_delimiter = "\n\f",
+                # extract_images = True,
+                # images_parser = RapidOCRBlobParser(),
+            )
+
+        Lazy load documents:
+
+        .. code-block:: python
+
+            docs = []
+            docs_lazy = loader.lazy_load()
+
+            for doc in docs_lazy:
+                docs.append(doc)
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+
+        Load documents asynchronously:
+
+        .. code-block:: python
+
+            docs = await loader.aload()
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+    """
+
+    def __init__(
+        self,
+        file_path: Union[str, PurePath],
+        password: Optional[Union[str, bytes]] = None,
+        headers: Optional[dict] = None,
+        extract_images: bool = False,
+        *,
+        mode: Literal["single", "page"] = "page",
+        images_parser: Optional[BaseImageBlobParser] = None,
+        images_inner_format: Literal["text", "markdown-img", "html-img"] = "text",
+        pages_delimiter: str = _DEFAULT_PAGES_DELIMITER,
+        extraction_mode: Literal["plain", "layout"] = "plain",
+        extraction_kwargs: Optional[dict] = None,
+    ) -> None:
+        """Initialize with a file path.
+
+        Args:
+            file_path: The path to the PDF file to be loaded.
+            headers: Optional headers to use for GET request to download a file from a
+              web path.
+            password: Optional password for opening encrypted PDFs.
+            mode: The extraction mode, either "single" for the entire document or "page"
+                for page-wise extraction.
+            pages_delimiter: A string delimiter to separate pages in single-mode
+                extraction.
+            extract_images: Whether to extract images from the PDF.
+            images_parser: Optional image blob parser.
+            images_inner_format: The format for the parsed output.
+                - "text" = return the content as is
+                - "markdown-img" = wrap the content into an image markdown link, w/ link
+                pointing to (`![body)(#)`]
+                - "html-img" = wrap the content as the `alt` text of an tag and link to
+                (`<img alt="{body}" src="#"/>`)
+            extraction_mode: “plain” for legacy functionality, “layout” extract text
+                in a fixed width format that closely adheres to the rendered layout in
+                the source pdf
+            extraction_kwargs: Optional additional parameters for the extraction
+                process.
+
+        Returns:
+            This method does not directly return data. Use the `load`, `lazy_load` or
+            `aload` methods to retrieve parsed documents with content and metadata.
+        """
+        super().__init__(file_path, headers=headers)
+        self.parser = PyPDFParser(
+            password=password,
+            mode=mode,
+            extract_images=extract_images,
+            images_parser=images_parser,
+            images_inner_format=images_inner_format,
+            pages_delimiter=pages_delimiter,
+            extraction_mode=extraction_mode,
+            extraction_kwargs=extraction_kwargs,
+        )
+
+    def lazy_load(
+        self,
+    ) -> Iterator[Document]:
+        """
+        Lazy load given path as pages.
+        Insert image, if possible, between two paragraphs.
+        In this way, a paragraph can be continued on the next page.
+        """
+        if self.web_path:
+            blob = Blob.from_data(open(self.file_path, "rb").read(), path=self.web_path)
+        else:
+            blob = Blob.from_path(self.file_path)
+        yield from self.parser.lazy_parse(blob)
+
+class PyPDFDirectoryLoader(BaseLoader):
+    """Load and parse a directory of PDF files using 'pypdf' library.
+
+    This class provides methods to load and parse multiple PDF documents in a directory,
+    supporting options for recursive search, handling password-protected files,
+    extracting images, and defining extraction modes. It integrates the `pypdf` library
+    for PDF processing and offers synchronous document loading.
+
+    Examples:
+        Setup:
+
+        .. code-block:: bash
+
+            pip install -U langchain-community pypdf
+
+        Instantiate the loader:
+
+        .. code-block:: python
+
+            from langchain_community.document_loaders import PyPDFDirectoryLoader
+
+            loader = PyPDFDirectoryLoader(
+                path = "./example_data/",
+                glob = "**/[!.]*.pdf",
+                silent_errors = False,
+                load_hidden = False,
+                recursive = False,
+                extract_images = False,
+                password = None,
+                mode = "page",
+                images_to_text = None,
+                headers = None,
+                extraction_mode = "plain",
+                # extraction_kwargs = None,
+            )
+
+        Load documents:
+
+        .. code-block:: python
+
+            docs = loader.load()
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+
+        Load documents asynchronously:
+
+        .. code-block:: python
+
+            docs = await loader.aload()
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+    """
+
+    def __init__(
+        self,
+        path: Union[str, PurePath],
+        glob: str = "**/[!.]*.pdf",
+        silent_errors: bool = False,
+        load_hidden: bool = False,
+        recursive: bool = False,
+        extract_images: bool = False,
+        *,
+        password: Optional[str] = None,
+        mode: Literal["single", "page"] = "page",
+        images_parser: Optional[BaseImageBlobParser] = None,
+        headers: Optional[dict] = None,
+        extraction_mode: Literal["plain", "layout"] = "plain",
+        extraction_kwargs: Optional[dict] = None,
+    ):
+        """Initialize with a directory path.
+
+        Args:
+            path: The path to the directory containing PDF files to be loaded.
+            glob: The glob pattern to match files in the directory.
+            silent_errors: Whether to log errors instead of raising them.
+            load_hidden: Whether to include hidden files in the search.
+            recursive: Whether to search subdirectories recursively.
+            extract_images: Whether to extract images from PDFs.
+            password: Optional password for opening encrypted PDFs.
+            mode: The extraction mode, either "single" for extracting the entire
+                document or "page" for page-wise extraction.
+            images_parser: Optional image blob parser..
+            headers: Optional headers to use for GET request to download a file from a
+              web path.
+            extraction_mode: “plain” for legacy functionality, “layout” for
+              experimental layout mode functionality
+            extraction_kwargs: Optional additional parameters for the extraction
+              process.
+
+        Returns:
+            This method does not directly return data. Use the `load` method to
+            retrieve parsed documents with content and metadata.
+        """
+        self.password = password
+        self.mode = mode
+        self.path = path
+        self.glob = glob
+        self.load_hidden = load_hidden
+        self.recursive = recursive
+        self.silent_errors = silent_errors
+        self.extract_images = extract_images
+        self.images_parser = images_parser
+        self.headers = headers
+        self.extraction_mode = extraction_mode
+        self.extraction_kwargs = extraction_kwargs
+
+    @staticmethod
+    def _is_visible(path: PurePath) -> bool:
+        return not any(part.startswith(".") for part in path.parts)
+
+    def load(self) -> list[Document]:
+        p = Path(self.path)
+        docs = []
+        items = p.rglob(self.glob) if self.recursive else p.glob(self.glob)
+        for i in items:
+            if i.is_file():
+                if self._is_visible(i.relative_to(p)) or self.load_hidden:
+                    try:
+                        loader = PyPDFLoader(
+                            str(i),
+                            password=self.password,
+                            mode=self.mode,
+                            extract_images=self.extract_images,
+                            images_parser=self.images_parser,
+                            headers=self.headers,
+                            extraction_mode=self.extraction_mode,
+                            extraction_kwargs=self.extraction_kwargs,
+                        )
+                        sub_docs = loader.load()
+                        for doc in sub_docs:
+                            doc.metadata["source"] = str(i)
+                        docs.extend(sub_docs)
+                    except Exception as e:
+                        if self.silent_errors:
+                            logger.warning(e)
+                        else:
+                            raise e
+        return docs


### PR DESCRIPTION
* Remove lint dependencies from dev target, as linting cannot be done within the app.  Too many dependency conflicts (anthropic causes pydoclint to crash, mypy typing bloats image size ~200 MB, etc).

* Vendor the tiny bits of langchain_community we need to drop that.

* Pull in lint deps for linting runs.

Implements: AP-470

---

Tested running the pipeline and it ran fine.  The LanceDB module was very easy to pull out of langchain_community; PyPDF not so much.  The lint dependencies are pulled on-demand in GitHub Actions.  It does not appear to cause any significant delay in runtime.