### PR TITLE
AP-459 Preventing references from crowding out answer in UI

### DIFF
--- a/public/elements/tind-refs.jsx
+++ b/public/elements/tind-refs.jsx
@@ -1,0 +1,21 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+
+export default function TindRefs () {
+  return (
+    <Accordion type="single" collapsible className="w-full">
+      <AccordionItem value="ref-1">
+        <AccordionTrigger>Metadata</AccordionTrigger>
+        <AccordionContent>
+          <p className="mb-2" style={{ whiteSpace: 'pre-line' }}>
+            {props.tind_message || 'no references supplied'}
+          </p>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/willa/web/app.py
+++ b/willa/web/app.py
@@ -38,6 +38,18 @@ async def ocs() -> None:
 async def on_chat_resume(thread: ThreadDict) -> None:
     """Resume chat session for data persistence."""
     await cl.context.emitter.set_commands(COMMANDS)
+
+    # recreate custom elements from metadata
+    # results in a duplicate message in data layer!!
+    # for msg in thread['steps']:
+    #     if 'tind_message' in msg['metadata']:
+    #         tind_refs = cl.CustomElement(name='tind-refs', props=msg['metadata'])
+    #         await cl.Message(
+    #             author='TIND',
+    #             content='References:',
+    #             elements=[tind_refs],
+    #             metadata=msg['metadata']
+    #             ).send()
 # pylint: enable="unused-argument"
 
 
@@ -89,8 +101,22 @@ async def chat(message: cl.Message) -> None:
             await cl.Message(content=reply['ai_message']).send()
 
         if 'tind_message' in reply:
-            await cl.Message(author='TIND',
-                             content=reply['tind_message']).send()
+            tind_refs = cl.CustomElement(
+                name='tind-refs',
+                props={'tind_message': reply['tind_message']}
+                )
+            msg = cl.Message(
+                author='TIND',
+                content='References:',
+                elements=[tind_refs],
+                metadata={'tind_message': reply['tind_message']}
+                )
+            await msg.send()
+
+            # print(f"Message ID: {msg.id}")
+            # print(f"Elements: {msg.elements}")
+            # print(f"Thread ID: {message.thread_id}")
+            # print(f"msg: {msg}")
 
         if 'no_results' in reply:
             await cl.Message(author='System', type='system_message',


### PR DESCRIPTION
Added a custom_element jsx to put the tind-refs into an accordion component from [chainlit's import of shadcn](https://docs.chainlit.io/api-reference/elements/custom).

There are issues with persisting the element to the data layer because we're not currently using a cloud storage integration.

Cloud storage is required in chainlit's `chainlit_data_layer.py` src, but it appears to be overly aggressive.  If we're not persisting any binary uploads as part of the element, then it should be able to work.

Current thoughts are to submit an issue upstream along with a proposed PR for the fix, hookup an S3/localstack integration (that won't be used!), or do some message manipulation on_chat_resume and just recreate them live...